### PR TITLE
feat(sidebar): base principal para la sidebar de navegacion (HU-014)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@fontsource/hubot-sans": "^5.2.8",
         "@fontsource/mona-sans": "^5.2.8",
         "axios": "^1.13.6",
+        "lucide-react": "^0.577.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.13.1"
@@ -3298,6 +3299,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.577.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.577.0.tgz",
+      "integrity": "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/math-intrinsics": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "@fontsource/hubot-sans": "^5.2.8",
     "@fontsource/mona-sans": "^5.2.8",
     "axios": "^1.13.6",
+    "lucide-react": "^0.577.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.13.1"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,17 +3,64 @@ import LoginPage from './pages/LoginPage';
 import DashboardPage from './pages/DashboardPage';
 import ChangePasswordPage from './pages/ChangePasswordPage';
 import { ProtectedRoute } from './components/ProtectedRoute';
+import { SidebarProvider } from './context/SidebarContext';
+import Sidebar from './components/Sidebar';
+import React from 'react';
+
+function LayoutWithSidebar({ children }: { children: React.ReactNode }) {
+  return (
+    <SidebarProvider>
+      <div className="flex min-h-screen">
+        <Sidebar />
+        <main className="flex-1 bg-neutral-bg">
+          {children}
+        </main>
+      </div>
+    </SidebarProvider>
+  );
+}
 
 function App() {
   return (
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<Navigate to="/login" replace />} />
-        
         <Route path="/login" element={<LoginPage />} />
-        
-        <Route path="/change-password" element={<ProtectedRoute><ChangePasswordPage/></ProtectedRoute>} />
-        <Route path="/dashboard" element={<ProtectedRoute><DashboardPage /></ProtectedRoute>} />
+        <Route path="/change-password" element={
+          <ProtectedRoute><ChangePasswordPage /></ProtectedRoute>
+        } />
+
+        {/* Rutas con sidebar */}
+        <Route path="/dashboard" element={
+          <ProtectedRoute>
+            <LayoutWithSidebar><DashboardPage /></LayoutWithSidebar>
+          </ProtectedRoute>
+        } />
+        <Route path="/family-office" element={
+          <ProtectedRoute>
+            <LayoutWithSidebar><h1 className="p-6">Family Office</h1></LayoutWithSidebar>
+          </ProtectedRoute>
+        } />
+        <Route path="/flujo-de-caja" element={
+          <ProtectedRoute>
+            <LayoutWithSidebar><h1 className="p-6">Flujo de Caja</h1></LayoutWithSidebar>
+          </ProtectedRoute>
+        } />
+        <Route path="/facturas" element={
+          <ProtectedRoute>
+            <LayoutWithSidebar><h1 className="p-6">Facturas</h1></LayoutWithSidebar>
+          </ProtectedRoute>
+        } />
+        <Route path="/reportes" element={
+          <ProtectedRoute>
+            <LayoutWithSidebar><h1 className="p-6">Reportes</h1></LayoutWithSidebar>
+          </ProtectedRoute>
+        } />
+        <Route path="/ajustes" element={
+          <ProtectedRoute>
+            <LayoutWithSidebar><h1 className="p-6">Ajustes</h1></LayoutWithSidebar>
+          </ProtectedRoute>
+        } />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,0 +1,112 @@
+import { useContext } from 'react';
+import { NavLink, useNavigate } from 'react-router-dom';
+import { AuthContext } from '../context/AuthContext';
+import { useSidebar } from '../context/SidebarContext';
+import {
+  LayoutDashboard,
+  Briefcase,
+  ArrowLeftRight,
+  FileText,
+  BarChart2,
+  Settings,
+  LogOut,
+  PanelLeftClose,
+  PanelLeftOpen,
+} from 'lucide-react';
+
+const navItems = [
+  {
+    section: 'Principal',
+    items: [
+      { label: 'Dashboard', icon: LayoutDashboard, path: '/dashboard' },
+      { label: 'Family Office', icon: Briefcase, path: '/family-office' },
+      { label: 'Flujo de Caja', icon: ArrowLeftRight, path: '/flujo-de-caja' },
+      { label: 'Facturas', icon: FileText, path: '/facturas' },
+      { label: 'Reportes', icon: BarChart2, path: '/reportes' },
+    ],
+  },
+  {
+    section: 'Sistema',
+    items: [
+      { label: 'Ajustes', icon: Settings, path: '/ajustes' },
+    ],
+  },
+];
+
+export default function Sidebar() {
+  const { isExpanded, toggle } = useSidebar();
+  const { logout } = useContext(AuthContext);
+  const navigate = useNavigate();
+
+  const handleLogout = () => {
+    logout();
+    navigate('/login');
+  };
+
+  return (
+    <aside className={`
+      ${isExpanded ? 'w-64' : 'w-[70px]'}
+      min-h-screen bg-primary flex flex-col transition-all duration-300 flex-shrink-0
+    `}>
+
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-5">
+        {isExpanded && (
+          <div className="flex items-center gap-3">
+            <div className="bg-secondary rounded-lg w-9 h-9 flex items-center justify-center text-white font-bold text-base">
+              C
+            </div>
+            <span className="text-white font-bold text-lg">Conexia</span>
+          </div>
+        )}
+        <button
+          onClick={toggle}
+          className={`text-white bg-transparent border-none cursor-pointer p-1 ${!isExpanded ? 'mx-auto' : ''}`}
+        >
+          {isExpanded ? <PanelLeftClose size={20} /> : <PanelLeftOpen size={20} />}
+        </button>
+      </div>
+
+      {/* Nav */}
+      <nav className="flex-1 px-2">
+        {navItems.map(({ section, items }) => (
+          <div key={section} className="mb-6">
+            {isExpanded && (
+              <p className="text-neutral-border text-xs px-2 mb-2 uppercase tracking-wide">
+                {section}
+              </p>
+            )}
+            {items.map(({ label, icon: Icon, path }) => (
+              <NavLink
+                key={path}
+                to={path}
+                className={({ isActive }) => `
+                  flex items-center gap-3 px-3 py-2.5 rounded-lg mb-1 no-underline transition-colors duration-200
+                  ${isActive
+                    ? 'bg-primary-hover text-white'
+                    : 'text-neutral-border hover:bg-primary-hover hover:text-white'}
+                `}
+              >
+                <Icon size={20} className="flex-shrink-0" />
+                {isExpanded && (
+                  <span className="text-sm whitespace-nowrap">{label}</span>
+                )}
+              </NavLink>
+            ))}
+          </div>
+        ))}
+      </nav>
+
+      {/* Logout */}
+      <div className="p-4">
+        <button
+          onClick={handleLogout}
+          className="flex items-center gap-3 text-neutral-border bg-transparent border-none cursor-pointer px-3 py-2.5 rounded-lg w-full hover:bg-primary-hover hover:text-white transition-colors duration-200"
+        >
+          <LogOut size={20} className="flex-shrink-0" />
+          {isExpanded && <span className="text-sm">Cerrar sesión</span>}
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/frontend/src/context/SidebarContext.tsx
+++ b/frontend/src/context/SidebarContext.tsx
@@ -1,0 +1,23 @@
+import { createContext, useContext, useState } from 'react';
+import type { ReactNode } from 'react';
+
+interface SidebarContextType {
+  isExpanded: boolean;
+  toggle: () => void;
+}
+
+const SidebarContext = createContext<SidebarContextType>({} as SidebarContextType);
+
+export const SidebarProvider = ({ children }: { children: ReactNode }) => {
+  const [isExpanded, setIsExpanded] = useState(true);
+
+  const toggle = () => setIsExpanded(prev => !prev);
+
+  return (
+    <SidebarContext.Provider value={{ isExpanded, toggle }}>
+      {children}
+    </SidebarContext.Provider>
+  );
+};
+
+export const useSidebar = () => useContext(SidebarContext);


### PR DESCRIPTION
## Objetivo
Implementar la barra lateral de navegación persistente (HU-Sidebar) como componente estructural de la interfaz, estableciendo el layout base que envolverá todas las vistas protegidas del sistema.

## Cambios Principales
**Infraestructura de Layout:** Creación del componente `LayoutWithSidebar` en `App.tsx` que envuelve todas las rutas protegidas, garantizando que la sidebar persista en pantalla durante toda la sesión del usuario.

**Estado Global de la Sidebar:** Creación de `SidebarContext.tsx` con el hook `useSidebar()` para manejar el estado expandido/minimizado de forma global, permitiendo que cualquier componente futuro pueda consumir o modificar ese estado.

**Componente `Sidebar.tsx`:**
- Navegación organizada en secciones (Principal y Sistema) con íconos de lucide-react.
- Indicador visual de sección activa mediante `NavLink` de React Router.
- Funcionalidad de expandir/minimizar con animación fluida — al minimizarse muestra solo íconos.
- Integración con `AuthContext` para ejecutar el logout correctamente desde la sidebar.
- Todos los estilos consumen la paleta de Tailwind definida en `tailwind.config.js`.

**Rutas Placeholder:** Se registraron en `App.tsx` las rutas `/family-office`, `/flujo-de-caja`, `/facturas`, `/reportes` y `/ajustes` con contenido temporal, listas para ser reemplazadas por sus respectivos componentes en sprints futuros.

## Cómo probar esto
Para aprobar este PR, por favor sigan estos pasos en local. Asegúrense de tener el servidor del backend corriendo (`uvicorn src.main:app --reload`), para esto entren a la carpeta del backend: `cd backend`.
Recuerden instalar antes los requirimientos y tener el archivo .env.

1. Hagan git fetch y cambien a esta rama: `git checkout feature/sidebar-navigation`
2. Entren a la carpeta del frontend: `cd frontend`.
3. Creen un archivo llamado .env en la raíz de la carpeta frontend y agreguen esta línea: `VITE_API_URL=http://localhost:8000`
4. Instalen dependencias nuevas: `npm install` (se agregó lucide-react)
5. Levanten el servidor: `npm run dev`
6. Inicien sesión con cualquier usuario válido.
7. Prueba 1 - Persistencia: Naveguen entre secciones del menú y verifiquen que la sidebar no desaparece.
8. Prueba 2 - Sección activa: Verifiquen que el ítem del menú correspondiente a la ruta actual se resalta visualmente.
9. Prueba 3 - Expandir/minimizar: Usen el botón del encabezado para colapsar la sidebar. Debe mostrar solo íconos y expandirse de nuevo al presionarlo.
10. Prueba 4 - Logout: Usen el botón "Cerrar sesión" de la sidebar y verifiquen que redirige al login correctamente.

## Notas Adicionales
Las rutas `/family-office`, `/flujo-de-caja`, `/facturas`, `/reportes` y `/ajustes` están registradas pero vacías intencionalmente. Cada una será completada por su respectiva HU en el futuro. No modificar `App.tsx` sin coordinar con el equipo para evitar conflictos de rutas. 