### PR TITLE
feat: centro notificaciones (HU-016)

### DIFF
--- a/backend/src/modules/family_office/deadlines/models.py
+++ b/backend/src/modules/family_office/deadlines/models.py
@@ -25,7 +25,6 @@ class Deadline(Base):
     __tablename__ = "deadlines"
 
     id = Column(Integer, primary_key=True, index=True)
-    company_id = Column(Integer, ForeignKey("companies.id"), nullable=False)
     name = Column(String, nullable=False)
     description = Column(String, nullable=True)
     due_date = Column(Date, nullable=False)

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -55,10 +55,7 @@ export default function Sidebar() {
   const { clearActiveCompany } = useCompany();
   const navigate = useNavigate();
   const roleLabel = user?.role?.replaceAll('_', ' ');
-  const hasEnabledAlerts =
-    user?.alert_deadlines_enabled ||
-    user?.alert_balances_enabled ||
-    user?.alert_reports_enabled;
+  const hasEnabledAlerts = user?.alert_deadlines_enabled;
 
   const handleLogout = () => {
     logout();
@@ -139,7 +136,7 @@ export default function Sidebar() {
             <NavLink
               to="/notificaciones"
               className={({ isActive }) => `
-                flex items-center gap-3 pl-2.5 pr-3 py-2.5 rounded-lg no-underline transition-all duration-200 border-l-2
+                relative flex items-center gap-3 pl-2.5 pr-3 py-2.5 rounded-lg no-underline transition-all duration-200 border-l-2
                 ${!isExpanded ? 'justify-center' : ''}
                 ${
                   isActive

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -49,13 +49,18 @@ const mainItems = [
   },
 ];
 
+const NOTIFICATIONS_ALLOWED_ROLES = ['admin', 'contador_family_office'];
+
 export default function Sidebar() {
   const { isExpanded, toggle } = useSidebar();
   const { logout, user } = useContext(AuthContext);
   const { clearActiveCompany } = useCompany();
   const navigate = useNavigate();
   const roleLabel = user?.role?.replaceAll('_', ' ');
-  const hasEnabledAlerts = user?.alert_deadlines_enabled;
+  const hasNotificationsAccess =
+    !!user?.role && NOTIFICATIONS_ALLOWED_ROLES.includes(user.role);
+  const hasEnabledAlerts = !!user?.alert_deadlines_enabled;
+  const canSeeNotifications = hasNotificationsAccess && hasEnabledAlerts;
 
   const handleLogout = () => {
     logout();
@@ -132,7 +137,7 @@ export default function Sidebar() {
         {/* Sección inferior */}
         <div className="px-2 pb-2 flex flex-col gap-1">
           {/* Notificaciones */}
-          {hasEnabledAlerts && (
+          {canSeeNotifications && (
             <NavLink
               to="/notificaciones"
               className={({ isActive }) => `

--- a/frontend/src/features/notifications/components/NotificationsPageSkeleton.tsx
+++ b/frontend/src/features/notifications/components/NotificationsPageSkeleton.tsx
@@ -1,0 +1,71 @@
+export default function NotificationsPageSkeleton() {
+  return (
+    <div className="min-h-screen bg-neutral-bg p-8 animate-pulse">
+      <div className="mx-auto max-w-6xl space-y-6">
+        {/* Header */}
+        <div className="mb-6">
+          <div className="flex flex-wrap items-center gap-3 mb-4">
+            <div className="h-9 w-48 bg-neutral-border rounded-lg" />
+            <div className="h-7 w-40 bg-neutral-border rounded-full" />
+          </div>
+          <div className="h-4 w-72 bg-neutral-border rounded" />
+        </div>
+
+        {/* Panel de resumen */}
+        <section className="rounded-3xl border border-neutral-border bg-neutral-surface p-6 shadow-sm space-y-4">
+          <div className="h-5 w-40 bg-neutral-border rounded" />
+          <div className="h-3 w-96 bg-neutral-border rounded" />
+
+          <div className="mt-5 grid gap-3 sm:grid-cols-2">
+            {/* Red card skeleton */}
+            <div className="rounded-2xl border border-neutral-border p-4">
+              <div className="h-3 w-20 bg-neutral-border rounded mb-2" />
+              <div className="h-8 w-12 bg-neutral-border rounded" />
+              <div className="h-2.5 w-48 bg-neutral-border rounded mt-3" />
+            </div>
+            {/* Green card skeleton */}
+            <div className="rounded-2xl border border-neutral-border p-4">
+              <div className="h-3 w-20 bg-neutral-border rounded mb-2" />
+              <div className="h-8 w-12 bg-neutral-border rounded" />
+              <div className="h-2.5 w-40 bg-neutral-border rounded mt-3" />
+            </div>
+          </div>
+        </section>
+
+        {/* Filters section */}
+        <section className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="h-4 w-48 bg-neutral-border rounded" />
+          <div className="h-10 w-56 bg-neutral-border rounded-lg" />
+        </section>
+
+        {/* Notifications grid */}
+        <div className="grid gap-4 md:grid-cols-2">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div
+              key={i}
+              className="rounded-2xl border border-neutral-border bg-neutral-surface p-4 shadow-sm space-y-3"
+            >
+              <div className="flex items-start justify-between">
+                <div className="flex-1 space-y-2">
+                  <div className="h-4 w-32 bg-neutral-border rounded" />
+                  <div className="h-3 w-48 bg-neutral-border rounded" />
+                </div>
+                <div className="w-8 h-8 bg-neutral-border rounded-lg flex-shrink-0 ml-2" />
+              </div>
+
+              <div className="space-y-2">
+                <div className="h-3 w-40 bg-neutral-border rounded" />
+                <div className="h-3 w-44 bg-neutral-border rounded" />
+              </div>
+
+              <div className="flex items-center justify-between pt-2">
+                <div className="h-2.5 w-24 bg-neutral-border rounded" />
+                <div className="h-9 w-32 bg-neutral-border rounded-lg" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -177,19 +177,10 @@ export const useNotifications = ({
           return currentIds;
         }
 
-        const nextReadIds = [...currentIds, notificationId];
-
-        if (user?.id) {
-          localStorage.setItem(
-            buildStorageKey(user.id),
-            JSON.stringify(nextReadIds)
-          );
-        }
-
-        return nextReadIds;
+        return [...currentIds, notificationId];
       });
     },
-    [user?.id]
+    []
   );
 
   const retry = useCallback(() => {

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -1,0 +1,207 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { UserProfile } from '../services/authService';
+import { getDeadlinesByCompany } from '../services/deadlineService';
+import type { Deadline } from '../services/deadlineService';
+
+type NotificationType = 'deadline';
+
+interface DeadlineNotificationSource {
+  companyId: number;
+  companyName?: string;
+  deadline: Deadline;
+}
+
+export interface NotificationItem {
+  id: string;
+  title: string;
+  message: string;
+  isoDate: string;
+  type: NotificationType;
+  companyId: number;
+  companyName?: string;
+  isRead: boolean;
+}
+
+interface UseNotificationsParams {
+  user: UserProfile | null;
+  companyIds: number[];
+  companyNameById?: Record<number, string>;
+}
+
+const buildStorageKey = (userId: number) =>
+  `conexia.notifications.read.${userId}`;
+
+const getStoredReadIds = (userId: number): string[] => {
+  const rawValue = localStorage.getItem(buildStorageKey(userId));
+
+  if (!rawValue) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(rawValue);
+    return Array.isArray(parsed)
+      ? parsed.filter((value) => typeof value === 'string')
+      : [];
+  } catch {
+    return [];
+  }
+};
+
+const compareByDueDateAsc = (a: Deadline, b: Deadline) => {
+  const aTime = new Date(a.due_date).getTime();
+  const bTime = new Date(b.due_date).getTime();
+  return aTime - bTime;
+};
+
+export const useNotifications = ({
+  user,
+  companyIds,
+  companyNameById = {},
+}: UseNotificationsParams) => {
+  const [sources, setSources] = useState<DeadlineNotificationSource[]>([]);
+  const [loading, setLoading] = useState(!!user?.alert_deadlines_enabled);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+  const [readIds, setReadIds] = useState<string[]>(() => {
+    // Intentar cargar del localStorage al montar
+    if (typeof window !== 'undefined' && user?.id) {
+      return getStoredReadIds(user.id);
+    }
+    return [];
+  });
+
+  useEffect(() => {
+    if (!user?.id) {
+      setReadIds([]);
+      return;
+    }
+
+    const storedIds = getStoredReadIds(user.id);
+    setReadIds(storedIds);
+  }, [user?.id]);
+
+  useEffect(() => {
+    if (!user?.id) {
+      return;
+    }
+
+    localStorage.setItem(buildStorageKey(user.id), JSON.stringify(readIds));
+  }, [readIds, user?.id]);
+
+  useEffect(() => {
+    const shouldLoadDeadlines = !!user?.alert_deadlines_enabled;
+
+    if (!shouldLoadDeadlines || companyIds.length === 0) {
+      setSources([]);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    let ignore = false;
+
+    const fetchNotificationsData = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const byCompany = await Promise.all(
+          companyIds.map(async (companyId) => {
+            const deadlinesData = await getDeadlinesByCompany(companyId);
+            return {
+              companyId,
+              companyName: companyNameById[companyId],
+              deadlinesData,
+            };
+          })
+        );
+
+        const mergedSources = byCompany
+          .flatMap(({ companyId, companyName, deadlinesData }) =>
+            deadlinesData
+              .filter((item) => item.status === 'pendiente')
+              .map((deadline) => ({ companyId, companyName, deadline }))
+          )
+          .sort((a, b) => compareByDueDateAsc(a.deadline, b.deadline));
+
+        if (!ignore) {
+          setSources(mergedSources);
+        }
+      } catch {
+        if (!ignore) {
+          setSources([]);
+          setError('No se pudieron cargar las notificaciones.');
+        }
+      } finally {
+        if (!ignore) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void fetchNotificationsData();
+
+    return () => {
+      ignore = true;
+    };
+  }, [companyIds, companyNameById, reloadKey, user?.alert_deadlines_enabled]);
+
+  const notifications = useMemo<NotificationItem[]>(() => {
+    return sources.map(({ companyId, companyName, deadline }) => {
+      const id = `deadline-${companyId}-${deadline.id}`;
+
+      const companyLabel = companyName ? `Empresa: ${companyName}. ` : '';
+
+      return {
+        id,
+        title: `Vencimiento: ${deadline.name}`,
+        message: `${companyLabel}${deadline.description || 'Revisa y gestiona este compromiso a tiempo.'}`,
+        isoDate: deadline.due_date,
+        type: 'deadline',
+        companyId,
+        companyName,
+        isRead: readIds.includes(id),
+      };
+    });
+  }, [readIds, sources]);
+
+  const unreadCount = useMemo(
+    () => notifications.filter((notification) => !notification.isRead).length,
+    [notifications]
+  );
+
+  const markAsRead = useCallback(
+    (notificationId: string) => {
+      setReadIds((currentIds) => {
+        if (currentIds.includes(notificationId)) {
+          return currentIds;
+        }
+
+        const nextReadIds = [...currentIds, notificationId];
+
+        if (user?.id) {
+          localStorage.setItem(
+            buildStorageKey(user.id),
+            JSON.stringify(nextReadIds)
+          );
+        }
+
+        return nextReadIds;
+      });
+    },
+    [user?.id]
+  );
+
+  const retry = useCallback(() => {
+    setReloadKey((current) => current + 1);
+  }, []);
+
+  return {
+    loading,
+    error,
+    notifications,
+    unreadCount,
+    markAsRead,
+    retry,
+  };
+};

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -170,18 +170,15 @@ export const useNotifications = ({
     [notifications]
   );
 
-  const markAsRead = useCallback(
-    (notificationId: string) => {
-      setReadIds((currentIds) => {
-        if (currentIds.includes(notificationId)) {
-          return currentIds;
-        }
+  const markAsRead = useCallback((notificationId: string) => {
+    setReadIds((currentIds) => {
+      if (currentIds.includes(notificationId)) {
+        return currentIds;
+      }
 
-        return [...currentIds, notificationId];
-      });
-    },
-    []
-  );
+      return [...currentIds, notificationId];
+    });
+  }, []);
 
   const retry = useCallback(() => {
     setReloadKey((current) => current + 1);

--- a/frontend/src/pages/NotificationsPage.tsx
+++ b/frontend/src/pages/NotificationsPage.tsx
@@ -48,7 +48,8 @@ export default function NotificationsPage() {
 
   const hasNotificationsAccess =
     !!user?.role && NOTIFICATIONS_ALLOWED_ROLES.includes(user.role);
-  const hasEnabledAlerts = hasNotificationsAccess && !!user?.alert_deadlines_enabled;
+  const hasEnabledAlerts =
+    hasNotificationsAccess && !!user?.alert_deadlines_enabled;
 
   useEffect(() => {
     if (!hasEnabledAlerts) {
@@ -179,22 +180,23 @@ export default function NotificationsPage() {
                 Sin acceso al centro de notificaciones
               </h2>
               <p className="mt-2 text-sm text-neutral-muted">
-                Este modulo esta disponible solo para admin y contador family office.
+                Este modulo esta disponible solo para admin y contador family
+                office.
               </p>
             </div>
           ) : (
-          <div className="rounded-3xl border border-dashed border-neutral-border bg-neutral-surface p-10 text-center shadow-sm">
-            <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-neutral-bg text-neutral-muted">
-              <BellOff size={22} />
+            <div className="rounded-3xl border border-dashed border-neutral-border bg-neutral-surface p-10 text-center shadow-sm">
+              <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-neutral-bg text-neutral-muted">
+                <BellOff size={22} />
+              </div>
+              <h2 className="text-lg font-bold text-neutral-text">
+                No hay alertas activas
+              </h2>
+              <p className="mt-2 text-sm text-neutral-muted">
+                Activa uno o más tipos de alertas desde Ajustes para volver a
+                ver este módulo.
+              </p>
             </div>
-            <h2 className="text-lg font-bold text-neutral-text">
-              No hay alertas activas
-            </h2>
-            <p className="mt-2 text-sm text-neutral-muted">
-              Activa uno o más tipos de alertas desde Ajustes para volver a ver
-              este módulo.
-            </p>
-          </div>
           )
         ) : isInitiallyLoading ? (
           <NotificationsPageSkeleton />

--- a/frontend/src/pages/NotificationsPage.tsx
+++ b/frontend/src/pages/NotificationsPage.tsx
@@ -1,60 +1,167 @@
-import { useContext } from 'react';
-import {
-  BellOff,
-  CalendarClock,
-  FileSpreadsheet,
-  Sparkles,
-} from 'lucide-react';
+import { useContext, useEffect, useMemo, useState } from 'react';
+import { BellOff, CalendarClock, CheckCircle2, BellRing } from 'lucide-react';
 import { AuthContext } from '../context/AuthContext';
+import { useCompany } from '../context/CompanyContext';
+import { useNotifications } from '../hooks/useNotifications';
+import { getCompanies } from '../services/companyService';
+import type { Company } from '../services/companyService';
+import NotificationsPageSkeleton from '../features/notifications/components/NotificationsPageSkeleton';
 
-const notificationBlocks = [
-  {
-    key: 'alert_deadlines_enabled',
-    title: 'Vencimientos por revisar',
-    description:
-      'Visualiza recordatorios de obligaciones pendientes y fechas próximas a vencer.',
+const formatNotificationDate = (isoDate: string) => {
+  return new Intl.DateTimeFormat('es-CO', {
+    day: '2-digit',
+    month: 'long',
+    year: 'numeric',
+  }).format(new Date(isoDate));
+};
+
+const getNotificationVisual = () => {
+  return {
     icon: CalendarClock,
-    accent: 'bg-secondary/15 text-secondary',
-  },
-  {
-    key: 'alert_balances_enabled',
-    title: 'Balances pendientes',
-    description:
-      'Consulta avisos relacionados con cargas y revisiones de balances operativos.',
-    icon: FileSpreadsheet,
-    accent: 'bg-primary/10 text-primary',
-  },
-  {
-    key: 'alert_reports_enabled',
-    title: 'Reportes disponibles',
-    description:
-      'Recibe notificaciones cuando existan resúmenes o reportes listos para consulta.',
-    icon: Sparkles,
-    accent: 'bg-amber-100 text-amber-700',
-  },
-] as const;
+    label: 'Vencimiento',
+    tone: 'text-secondary',
+  };
+};
 
 export default function NotificationsPage() {
   const { user } = useContext(AuthContext);
+  const { activeCompany } = useCompany();
+  const [companies, setCompanies] = useState<Company[]>([]);
+  const [selectedCompanyFilter, setSelectedCompanyFilter] =
+    useState<string>('all');
+  const [activeTab, setActiveTab] = useState<'pending' | 'read'>('pending');
+  const [companiesLoading, setCompaniesLoading] = useState(true);
+  const [companiesError, setCompaniesError] = useState<string | null>(null);
+  const [companiesReloadKey, setCompaniesReloadKey] = useState(0);
+
+  const hasEnabledAlerts = !!user?.alert_deadlines_enabled;
+
+  useEffect(() => {
+    if (!hasEnabledAlerts) {
+      setCompanies([]);
+      setCompaniesLoading(false);
+      setCompaniesError(null);
+      return;
+    }
+
+    let ignore = false;
+
+    const fetchCompanies = async () => {
+      setCompaniesLoading(true);
+      setCompaniesError(null);
+      try {
+        const data = await getCompanies();
+        if (!ignore) {
+          setCompanies(data);
+        }
+      } catch {
+        if (!ignore) {
+          setCompanies([]);
+          setCompaniesError('No se pudieron cargar las empresas.');
+        }
+      } finally {
+        if (!ignore) {
+          setCompaniesLoading(false);
+        }
+      }
+    };
+
+    void fetchCompanies();
+
+    return () => {
+      ignore = true;
+    };
+  }, [companiesReloadKey, hasEnabledAlerts]);
+
+  useEffect(() => {
+    if (activeCompany?.id && selectedCompanyFilter === 'all') {
+      setSelectedCompanyFilter(String(activeCompany.id));
+    }
+  }, [activeCompany?.id, selectedCompanyFilter]);
+
+  const companyNameById = useMemo(() => {
+    return companies.reduce<Record<number, string>>((acc, company) => {
+      acc[company.id] = company.name;
+      return acc;
+    }, {});
+  }, [companies]);
+
+  const companyIds = useMemo(() => {
+    if (selectedCompanyFilter !== 'all') {
+      return [Number(selectedCompanyFilter)].filter((id) =>
+        Number.isFinite(id)
+      );
+    }
+
+    if (companies.length > 0) {
+      return companies.map((company) => company.id);
+    }
+
+    if (activeCompany?.id) {
+      return [activeCompany.id];
+    }
+
+    return [];
+  }, [activeCompany?.id, companies, selectedCompanyFilter]);
+
+  const {
+    notifications,
+    unreadCount,
+    markAsRead,
+    loading,
+    error: notificationsError,
+    retry: retryNotifications,
+  } = useNotifications({
+    user,
+    companyIds,
+    companyNameById,
+  });
+
+  const readCount = notifications.length - unreadCount;
+  const pendingNotifications = notifications.filter(
+    (notification) => !notification.isRead
+  );
+  const readNotifications = notifications.filter(
+    (notification) => notification.isRead
+  );
+  const visibleNotifications =
+    activeTab === 'pending' ? pendingNotifications : readNotifications;
+  const activeLoadError = companiesError ?? notificationsError;
+
+  const isInitiallyLoading =
+    companiesLoading || (loading && companies.length === 0);
+
+  const handleRetry = () => {
+    if (companiesError) {
+      setCompaniesReloadKey((current) => current + 1);
+    }
+
+    if (notificationsError) {
+      retryNotifications();
+    }
+  };
 
   if (!user) return null;
 
-  const visibleBlocks = notificationBlocks.filter(({ key }) => user[key]);
-
   return (
     <div className="min-h-screen bg-neutral-bg p-8">
-      <div className="mx-auto max-w-5xl">
+      <div className="mx-auto max-w-6xl">
         <div className="mb-6">
-          <h1 className="text-3xl font-bold text-neutral-text font-hubot tracking-tight">
-            Notificaciones
-          </h1>
+          <div className="flex flex-wrap items-center gap-3">
+            <h1 className="text-3xl font-bold text-neutral-text font-hubot tracking-tight">
+              Notificaciones
+            </h1>
+            <span className="inline-flex items-center gap-1 rounded-full border border-red-700 bg-red-600 px-3 py-1 text-xs font-bold text-white">
+              <BellRing size={14} />
+              Pendientes: {unreadCount}
+            </span>
+          </div>
           <p className="mt-1 text-sm text-neutral-muted">
-            Centro de alertas visible según las preferencias activas en tu
-            perfil.
+            Revisa alertas recientes y marca como leídas las que ya atendiste.
           </p>
         </div>
 
-        {visibleBlocks.length === 0 ? (
+        {!hasEnabledAlerts ? (
           <div className="rounded-3xl border border-dashed border-neutral-border bg-neutral-surface p-10 text-center shadow-sm">
             <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-neutral-bg text-neutral-muted">
               <BellOff size={22} />
@@ -67,28 +174,195 @@ export default function NotificationsPage() {
               este módulo.
             </p>
           </div>
+        ) : isInitiallyLoading ? (
+          <NotificationsPageSkeleton />
         ) : (
-          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-            {visibleBlocks.map(
-              ({ key, title, description, icon: Icon, accent }) => (
-                <article
-                  key={key}
-                  className="rounded-3xl border border-neutral-border bg-neutral-surface p-6 shadow-sm"
-                >
-                  <div
-                    className={`mb-4 flex h-12 w-12 items-center justify-center rounded-2xl ${accent}`}
-                  >
-                    <Icon size={20} />
-                  </div>
-                  <h2 className="text-base font-bold text-neutral-text">
-                    {title}
-                  </h2>
-                  <p className="mt-2 text-sm text-neutral-muted">
-                    {description}
+          <div className="space-y-4">
+            <section className="rounded-3xl border border-neutral-border bg-neutral-surface p-6 shadow-sm">
+              <h3 className="text-base font-bold text-neutral-text">
+                Panel de resumen
+              </h3>
+              <p className="mt-1 text-sm text-neutral-muted">
+                Estado actual de tus alertas y acciones recomendadas.
+              </p>
+
+              <div className="mt-5 grid gap-3 sm:grid-cols-2">
+                <div className="rounded-2xl border-2 border-red-400 p-4">
+                  <p className="text-xs uppercase tracking-wide text-red-700">
+                    Pendientes
                   </p>
-                </article>
-              )
-            )}
+                  <p className="mt-1 text-2xl font-bold text-red-700">
+                    {unreadCount}
+                  </p>
+                </div>
+
+                <div className="rounded-2xl border-2 border-emerald-400 p-4">
+                  <p className="text-xs uppercase tracking-wide text-emerald-700">
+                    Leídas
+                  </p>
+                  <p className="mt-1 text-2xl font-bold text-emerald-700">
+                    {readCount}
+                  </p>
+                </div>
+              </div>
+            </section>
+
+            <section className="rounded-3xl border border-neutral-border bg-neutral-surface p-4 shadow-sm md:p-6">
+              <div className="mb-4 flex flex-wrap items-end justify-between gap-3">
+                <div className="space-y-3">
+                  <h2 className="text-base font-bold text-neutral-text">
+                    Avisos recientes
+                  </h2>
+                  <div
+                    role="tablist"
+                    aria-label="Pestañas de notificaciones"
+                    className="inline-flex rounded-xl border border-neutral-border bg-white p-1"
+                  >
+                    <button
+                      type="button"
+                      role="tab"
+                      aria-selected={activeTab === 'pending'}
+                      onClick={() => setActiveTab('pending')}
+                      className={`rounded-lg px-3 py-1.5 text-xs font-semibold transition ${
+                        activeTab === 'pending'
+                          ? 'bg-primary text-white'
+                          : 'text-neutral-muted hover:text-neutral-text'
+                      }`}
+                    >
+                      Pendientes ({unreadCount})
+                    </button>
+                    <button
+                      type="button"
+                      role="tab"
+                      aria-selected={activeTab === 'read'}
+                      onClick={() => setActiveTab('read')}
+                      className={`rounded-lg px-3 py-1.5 text-xs font-semibold transition ${
+                        activeTab === 'read'
+                          ? 'bg-primary text-white'
+                          : 'text-neutral-muted hover:text-neutral-text'
+                      }`}
+                    >
+                      Leídas ({readCount})
+                    </button>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <label
+                    htmlFor="notifications-company-filter"
+                    className="text-xs font-semibold uppercase tracking-wide text-neutral-muted"
+                  >
+                    Ver todas o filtrar por empresa
+                  </label>
+                  <select
+                    id="notifications-company-filter"
+                    value={selectedCompanyFilter}
+                    onChange={(event) =>
+                      setSelectedCompanyFilter(event.target.value)
+                    }
+                    className="rounded-lg border border-neutral-border bg-white px-3 py-2 text-sm text-neutral-text"
+                  >
+                    <option value="all">Todas</option>
+                    {companies.map((company) => (
+                      <option key={company.id} value={String(company.id)}>
+                        {company.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+
+              <div className="grid gap-3 md:grid-cols-2">
+                {activeLoadError ? (
+                  <div className="md:col-span-2 rounded-2xl border border-danger/30 bg-danger/5 p-6 text-center">
+                    <p className="text-sm font-semibold text-danger">
+                      {activeLoadError}
+                    </p>
+                    <p className="mt-1 text-sm text-neutral-muted">
+                      Verifica tu conexión e intenta nuevamente.
+                    </p>
+                    <button
+                      type="button"
+                      onClick={handleRetry}
+                      className="mt-4 inline-flex items-center rounded-lg border border-danger/40 px-3 py-1.5 text-xs font-semibold text-danger transition hover:bg-danger/10"
+                    >
+                      Intentar de nuevo
+                    </button>
+                  </div>
+                ) : visibleNotifications.length === 0 ? (
+                  <div className="md:col-span-2 rounded-2xl border border-neutral-border bg-neutral-bg p-6 text-center">
+                    <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-xl bg-secondary/15 text-secondary">
+                      <CheckCircle2 size={20} />
+                    </div>
+                    <p className="text-sm font-semibold text-neutral-text">
+                      {activeTab === 'pending'
+                        ? 'No hay pendientes por revisar'
+                        : 'No hay notificaciones leídas'}
+                    </p>
+                    <p className="mt-1 text-sm text-neutral-muted">
+                      {activeTab === 'pending'
+                        ? 'No se encontraron notificaciones pendientes para el filtro seleccionado.'
+                        : 'Marca notificaciones como leídas para verlas en esta pestaña.'}
+                    </p>
+                  </div>
+                ) : (
+                  visibleNotifications.map((notification) => {
+                    const visual = getNotificationVisual();
+                    const Icon = visual.icon;
+                    const titleWithoutPrefix = notification.title.replace(
+                      /^Vencimiento:\s*/,
+                      ''
+                    );
+
+                    return (
+                      <article
+                        key={notification.id}
+                        className={`h-full rounded-2xl border p-4 transition flex flex-col ${
+                          notification.isRead
+                            ? 'border-neutral-border/80 bg-neutral-bg/70 opacity-70'
+                            : 'border-neutral-border bg-white'
+                        }`}
+                      >
+                        <div className="mb-3 flex items-center gap-2">
+                          <Icon size={16} className={visual.tone} />
+                          <span className="rounded-full border border-neutral-border px-2 py-0.5 text-[10px] uppercase tracking-wide text-neutral-muted">
+                            {visual.label}
+                          </span>
+                        </div>
+
+                        <h3 className="mb-2 font-semibold text-neutral-text">
+                          {titleWithoutPrefix}
+                        </h3>
+
+                        <p className="mb-3 flex-1 text-sm text-neutral-muted">
+                          {notification.message}
+                        </p>
+
+                        <div className="flex items-end justify-between gap-2">
+                          {notification.isRead ? (
+                            <span className="inline-flex items-center gap-1 rounded-lg border border-neutral-border bg-white/80 px-3 py-1.5 text-xs font-semibold text-neutral-muted">
+                              <CheckCircle2 size={14} />
+                              Leída
+                            </span>
+                          ) : (
+                            <button
+                              type="button"
+                              onClick={() => markAsRead(notification.id)}
+                              className="inline-flex items-center gap-1 rounded-lg border border-neutral-border px-3 py-1.5 text-xs font-semibold text-neutral-text transition hover:border-secondary hover:text-secondary"
+                            >
+                              <CheckCircle2 size={14} />
+                              Marcar como leída
+                            </button>
+                          )}
+                          <span className="text-xs text-neutral-muted whitespace-nowrap">
+                            {formatNotificationDate(notification.isoDate)}
+                          </span>
+                        </div>
+                      </article>
+                    );
+                  })
+                )}
+              </div>
+            </section>
           </div>
         )}
       </div>

--- a/frontend/src/pages/NotificationsPage.tsx
+++ b/frontend/src/pages/NotificationsPage.tsx
@@ -7,12 +7,24 @@ import { getCompanies } from '../services/companyService';
 import type { Company } from '../services/companyService';
 import NotificationsPageSkeleton from '../features/notifications/components/NotificationsPageSkeleton';
 
+const NOTIFICATIONS_ALLOWED_ROLES = ['admin', 'contador_family_office'];
+
 const formatNotificationDate = (isoDate: string) => {
+  const [year, month, day] = isoDate
+    .split('T')[0]
+    .split('-')
+    .map((value) => Number(value));
+
+  const parsedDate =
+    Number.isFinite(year) && Number.isFinite(month) && Number.isFinite(day)
+      ? new Date(year, month - 1, day)
+      : new Date(isoDate);
+
   return new Intl.DateTimeFormat('es-CO', {
     day: '2-digit',
     month: 'long',
     year: 'numeric',
-  }).format(new Date(isoDate));
+  }).format(parsedDate);
 };
 
 const getNotificationVisual = () => {
@@ -34,7 +46,9 @@ export default function NotificationsPage() {
   const [companiesError, setCompaniesError] = useState<string | null>(null);
   const [companiesReloadKey, setCompaniesReloadKey] = useState(0);
 
-  const hasEnabledAlerts = !!user?.alert_deadlines_enabled;
+  const hasNotificationsAccess =
+    !!user?.role && NOTIFICATIONS_ALLOWED_ROLES.includes(user.role);
+  const hasEnabledAlerts = hasNotificationsAccess && !!user?.alert_deadlines_enabled;
 
   useEffect(() => {
     if (!hasEnabledAlerts) {
@@ -72,12 +86,6 @@ export default function NotificationsPage() {
       ignore = true;
     };
   }, [companiesReloadKey, hasEnabledAlerts]);
-
-  useEffect(() => {
-    if (activeCompany?.id && selectedCompanyFilter === 'all') {
-      setSelectedCompanyFilter(String(activeCompany.id));
-    }
-  }, [activeCompany?.id, selectedCompanyFilter]);
 
   const companyNameById = useMemo(() => {
     return companies.reduce<Record<number, string>>((acc, company) => {
@@ -162,6 +170,19 @@ export default function NotificationsPage() {
         </div>
 
         {!hasEnabledAlerts ? (
+          !hasNotificationsAccess ? (
+            <div className="rounded-3xl border border-dashed border-neutral-border bg-neutral-surface p-10 text-center shadow-sm">
+              <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-neutral-bg text-neutral-muted">
+                <BellOff size={22} />
+              </div>
+              <h2 className="text-lg font-bold text-neutral-text">
+                Sin acceso al centro de notificaciones
+              </h2>
+              <p className="mt-2 text-sm text-neutral-muted">
+                Este modulo esta disponible solo para admin y contador family office.
+              </p>
+            </div>
+          ) : (
           <div className="rounded-3xl border border-dashed border-neutral-border bg-neutral-surface p-10 text-center shadow-sm">
             <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-neutral-bg text-neutral-muted">
               <BellOff size={22} />
@@ -174,6 +195,7 @@ export default function NotificationsPage() {
               este módulo.
             </p>
           </div>
+          )
         ) : isInitiallyLoading ? (
           <NotificationsPageSkeleton />
         ) : (
@@ -196,11 +218,11 @@ export default function NotificationsPage() {
                   </p>
                 </div>
 
-                <div className="rounded-2xl border-2 border-emerald-400 p-4">
-                  <p className="text-xs uppercase tracking-wide text-emerald-700">
+                <div className="rounded-2xl border-2 border-primary p-4">
+                  <p className="text-xs uppercase tracking-wide text-primary">
                     Leídas
                   </p>
-                  <p className="mt-1 text-2xl font-bold text-emerald-700">
+                  <p className="mt-1 text-2xl font-bold text-primary">
                     {readCount}
                   </p>
                 </div>


### PR DESCRIPTION
## Objetivo
Implementar el centro de notificaciones con mejor UX y manejo de errores. #27 

## Cambios Principales
- Se agregó `useNotifications` para centralizar carga, estado leído/no leído y persistencia.
- Se actualizó `NotificationsPage` con skeleton inicial, tabs (`Pendientes` / `Leídas`) y botón `Intentar de nuevo` ante error.
- Se ajustó `Sidebar` para no disparar cargas de notificaciones fuera del módulo.

## Como probarlo
- Ir a `/notificaciones`.
- Verificar skeleton al entrar.
- Marcar una notificación como leída y confirmar que pasa a la pestaña `Leídas`.

## Notas Adicionales
Sin cambios de backend.