### PR TITLE
feat: agregar cierre mensual de caja con validaciones de secuencia y …

### DIFF
--- a/backend/alembic/versions/a1b2c3d4e5f6_create_cash_monthly_closings.py
+++ b/backend/alembic/versions/a1b2c3d4e5f6_create_cash_monthly_closings.py
@@ -1,0 +1,75 @@
+"""create_cash_monthly_closings
+
+Revision ID: a1b2c3d4e5f6
+Revises: 9f2c1d4a7b11
+Create Date: 2026-04-14 10:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "a1b2c3d4e5f6"
+down_revision: Union[str, None] = "9f2c1d4a7b11"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "cash_monthly_closings",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("account_id", sa.Integer(), nullable=False),
+        sa.Column("year", sa.Integer(), nullable=False),
+        sa.Column("month", sa.Integer(), nullable=False),
+        sa.Column("opening_balance", sa.Numeric(14, 2), nullable=False),
+        sa.Column("total_income", sa.Numeric(14, 2), nullable=False),
+        sa.Column("total_expenses", sa.Numeric(14, 2), nullable=False),
+        sa.Column("closing_balance", sa.Numeric(14, 2), nullable=False),
+        sa.Column(
+            "is_closed", sa.Boolean(), nullable=False, server_default="false"
+        ),
+        sa.Column("closed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("closed_by_user_id", sa.Integer(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["account_id"],
+            ["cash_accounts.id"],
+            ondelete="RESTRICT",
+        ),
+        sa.ForeignKeyConstraint(
+            ["closed_by_user_id"],
+            ["users.id"],
+            ondelete="SET NULL",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "account_id", "year", "month", name="uq_closing_account_year_month"
+        ),
+    )
+    op.create_index(
+        "ix_cash_monthly_closings_id", "cash_monthly_closings", ["id"]
+    )
+    op.create_index(
+        "ix_cash_monthly_closings_account_id",
+        "cash_monthly_closings",
+        ["account_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_cash_monthly_closings_account_id",
+        table_name="cash_monthly_closings",
+    )
+    op.drop_index(
+        "ix_cash_monthly_closings_id", table_name="cash_monthly_closings"
+    )
+    op.drop_table("cash_monthly_closings")

--- a/backend/src/modules/cole_co/cash_flow/models.py
+++ b/backend/src/modules/cole_co/cash_flow/models.py
@@ -1,6 +1,7 @@
 import enum
 
 from sqlalchemy import (
+    Boolean,
     Column,
     Date,
     DateTime,
@@ -8,6 +9,7 @@ from sqlalchemy import (
     Integer,
     Numeric,
     String,
+    UniqueConstraint,
     func,
 )
 from sqlalchemy import Enum as SqlEnum
@@ -44,6 +46,12 @@ class CashAccount(Base):
         cascade="save-update, merge",
         passive_deletes=True,
     )
+    closings = relationship(
+        "CashMonthlyClosing",
+        back_populates="account",
+        cascade="save-update, merge",
+        passive_deletes=True,
+    )
 
 
 class CashMovement(Base):
@@ -75,3 +83,36 @@ class CashMovement(Base):
     @property
     def account_name(self) -> str:
         return self.account.name
+
+
+class CashMonthlyClosing(Base):
+    __tablename__ = "cash_monthly_closings"
+    __table_args__ = (
+        UniqueConstraint(
+            "account_id", "year", "month", name="uq_closing_account_year_month"
+        ),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    account_id = Column(
+        Integer,
+        ForeignKey("cash_accounts.id", ondelete="RESTRICT"),
+        nullable=False,
+        index=True,
+    )
+    year = Column(Integer, nullable=False)
+    month = Column(Integer, nullable=False)
+    opening_balance = Column(Numeric(14, 2), nullable=False)
+    total_income = Column(Numeric(14, 2), nullable=False)
+    total_expenses = Column(Numeric(14, 2), nullable=False)
+    closing_balance = Column(Numeric(14, 2), nullable=False)
+    is_closed = Column(Boolean, nullable=False, default=False)
+    closed_at = Column(DateTime(timezone=True), nullable=True)
+    closed_by_user_id = Column(
+        Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+    created_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    account = relationship("CashAccount", back_populates="closings")

--- a/backend/src/modules/cole_co/cash_flow/router.py
+++ b/backend/src/modules/cole_co/cash_flow/router.py
@@ -55,3 +55,44 @@ def create_cash_movement(
     current_user=Depends(auth_dependencies.require_role(ALLOWED_ROLES)),
 ):
     return service.create_movement(db, payload)
+
+
+@router.get(
+    "/monthly-summary",
+    response_model=schemas.MonthlySummaryResponse,
+)
+def get_monthly_summary(
+    account_id: int,
+    year: int,
+    month: int,
+    db: Session = Depends(get_db),
+    current_user=Depends(auth_dependencies.require_role(ALLOWED_ROLES)),
+):
+    return service.get_monthly_summary(db, account_id, year, month)
+
+
+@router.post(
+    "/monthly-close",
+    response_model=schemas.MonthlyClosingResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def close_month(
+    payload: schemas.MonthlyCloseRequest,
+    db: Session = Depends(get_db),
+    current_user=Depends(auth_dependencies.require_role(ALLOWED_ROLES)),
+):
+    return service.close_month(
+        db, payload.account_id, payload.year, payload.month, current_user.id
+    )
+
+
+@router.get(
+    "/monthly-closings",
+    response_model=list[schemas.MonthlyClosingResponse],
+)
+def get_monthly_closings(
+    account_id: int,
+    db: Session = Depends(get_db),
+    current_user=Depends(auth_dependencies.require_role(ALLOWED_ROLES)),
+):
+    return service.list_closings(db, account_id)

--- a/backend/src/modules/cole_co/cash_flow/schemas.py
+++ b/backend/src/modules/cole_co/cash_flow/schemas.py
@@ -44,3 +44,40 @@ class CashMovementResponse(BaseModel):
     created_at: datetime
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class MonthlySummaryResponse(BaseModel):
+    account_id: int
+    account_name: str
+    year: int
+    month: int
+    opening_balance: Decimal
+    total_income: Decimal
+    total_expenses: Decimal
+    closing_balance: Decimal
+    is_closed: bool
+    closed_at: datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class MonthlyCloseRequest(BaseModel):
+    account_id: int
+    year: int = Field(..., ge=2020, le=2100)
+    month: int = Field(..., ge=1, le=12)
+
+
+class MonthlyClosingResponse(BaseModel):
+    id: int
+    account_id: int
+    year: int
+    month: int
+    opening_balance: Decimal
+    total_income: Decimal
+    total_expenses: Decimal
+    closing_balance: Decimal
+    is_closed: bool
+    closed_at: datetime | None = None
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/src/modules/cole_co/cash_flow/service.py
+++ b/backend/src/modules/cole_co/cash_flow/service.py
@@ -204,9 +204,7 @@ def _compute_month_totals(
 
 def get_monthly_summary(db: Session, account_id: int, year: int, month: int):
     account = (
-        db.query(models.CashAccount)
-        .filter(models.CashAccount.id == account_id)
-        .first()
+        db.query(models.CashAccount).filter(models.CashAccount.id == account_id).first()
     )
     if not account:
         raise HTTPException(

--- a/backend/src/modules/cole_co/cash_flow/service.py
+++ b/backend/src/modules/cole_co/cash_flow/service.py
@@ -315,9 +315,10 @@ def close_month(db: Session, account_id: int, year: int, month: int, user_id: in
                 .first()
             )
             if not prev_closing:
+                prev_label = f"{prev_month:02d}/{prev_year}"
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
-                    detail=f"Debe cerrar el mes anterior ({prev_month:02d}/{prev_year}) primero",
+                    detail=f"Debe cerrar el mes anterior ({prev_label}) primero",
                 )
 
     opening = _compute_opening_balance(db, account, year, month)

--- a/backend/src/modules/cole_co/cash_flow/service.py
+++ b/backend/src/modules/cole_co/cash_flow/service.py
@@ -1,6 +1,8 @@
+from datetime import date
 from decimal import Decimal
 
 from fastapi import HTTPException, status
+from sqlalchemy import func as sa_func
 from sqlalchemy.orm import Session, joinedload
 
 from . import models, schemas
@@ -58,6 +60,22 @@ def create_movement(db: Session, payload: schemas.CashMovementCreate):
             detail="La cuenta seleccionada no existe",
         )
 
+    closing = (
+        db.query(models.CashMonthlyClosing)
+        .filter(
+            models.CashMonthlyClosing.account_id == payload.account_id,
+            models.CashMonthlyClosing.year == payload.movement_date.year,
+            models.CashMonthlyClosing.month == payload.movement_date.month,
+            models.CashMonthlyClosing.is_closed.is_(True),
+        )
+        .first()
+    )
+    if closing:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No se pueden registrar movimientos en un mes cerrado",
+        )
+
     amount = Decimal(payload.amount)
 
     if (
@@ -87,3 +105,251 @@ def create_movement(db: Session, payload: schemas.CashMovementCreate):
     db.commit()
     db.refresh(movement)
     return movement
+
+
+def _compute_opening_balance(
+    db: Session, account: models.CashAccount, year: int, month: int
+) -> Decimal:
+    if month == 1:
+        prev_year, prev_month = year - 1, 12
+    else:
+        prev_year, prev_month = year, month - 1
+
+    prev_closing = (
+        db.query(models.CashMonthlyClosing)
+        .filter(
+            models.CashMonthlyClosing.account_id == account.id,
+            models.CashMonthlyClosing.year == prev_year,
+            models.CashMonthlyClosing.month == prev_month,
+            models.CashMonthlyClosing.is_closed.is_(True),
+        )
+        .first()
+    )
+    if prev_closing:
+        return prev_closing.closing_balance
+
+    first_of_month = date(year, month, 1)
+
+    total_income_all = (
+        db.query(sa_func.coalesce(sa_func.sum(models.CashMovement.amount), 0))
+        .filter(
+            models.CashMovement.account_id == account.id,
+            models.CashMovement.movement_type == models.CashMovementType.INGRESO,
+        )
+        .scalar()
+    )
+    total_expense_all = (
+        db.query(sa_func.coalesce(sa_func.sum(models.CashMovement.amount), 0))
+        .filter(
+            models.CashMovement.account_id == account.id,
+            models.CashMovement.movement_type == models.CashMovementType.EGRESO,
+        )
+        .scalar()
+    )
+    initial_balance = account.current_balance - total_income_all + total_expense_all
+
+    income_before = (
+        db.query(sa_func.coalesce(sa_func.sum(models.CashMovement.amount), 0))
+        .filter(
+            models.CashMovement.account_id == account.id,
+            models.CashMovement.movement_type == models.CashMovementType.INGRESO,
+            models.CashMovement.movement_date < first_of_month,
+        )
+        .scalar()
+    )
+    expense_before = (
+        db.query(sa_func.coalesce(sa_func.sum(models.CashMovement.amount), 0))
+        .filter(
+            models.CashMovement.account_id == account.id,
+            models.CashMovement.movement_type == models.CashMovementType.EGRESO,
+            models.CashMovement.movement_date < first_of_month,
+        )
+        .scalar()
+    )
+
+    return initial_balance + income_before - expense_before
+
+
+def _compute_month_totals(
+    db: Session, account_id: int, year: int, month: int
+) -> tuple[Decimal, Decimal]:
+    first_of_month = date(year, month, 1)
+    if month == 12:
+        first_of_next = date(year + 1, 1, 1)
+    else:
+        first_of_next = date(year, month + 1, 1)
+
+    total_income = (
+        db.query(sa_func.coalesce(sa_func.sum(models.CashMovement.amount), 0))
+        .filter(
+            models.CashMovement.account_id == account_id,
+            models.CashMovement.movement_type == models.CashMovementType.INGRESO,
+            models.CashMovement.movement_date >= first_of_month,
+            models.CashMovement.movement_date < first_of_next,
+        )
+        .scalar()
+    )
+    total_expenses = (
+        db.query(sa_func.coalesce(sa_func.sum(models.CashMovement.amount), 0))
+        .filter(
+            models.CashMovement.account_id == account_id,
+            models.CashMovement.movement_type == models.CashMovementType.EGRESO,
+            models.CashMovement.movement_date >= first_of_month,
+            models.CashMovement.movement_date < first_of_next,
+        )
+        .scalar()
+    )
+    return Decimal(total_income), Decimal(total_expenses)
+
+
+def get_monthly_summary(db: Session, account_id: int, year: int, month: int):
+    account = (
+        db.query(models.CashAccount)
+        .filter(models.CashAccount.id == account_id)
+        .first()
+    )
+    if not account:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="La cuenta no existe",
+        )
+
+    existing = (
+        db.query(models.CashMonthlyClosing)
+        .filter(
+            models.CashMonthlyClosing.account_id == account_id,
+            models.CashMonthlyClosing.year == year,
+            models.CashMonthlyClosing.month == month,
+            models.CashMonthlyClosing.is_closed.is_(True),
+        )
+        .first()
+    )
+    if existing:
+        return {
+            "account_id": account_id,
+            "account_name": account.name,
+            "year": year,
+            "month": month,
+            "opening_balance": existing.opening_balance,
+            "total_income": existing.total_income,
+            "total_expenses": existing.total_expenses,
+            "closing_balance": existing.closing_balance,
+            "is_closed": True,
+            "closed_at": existing.closed_at,
+        }
+
+    opening = _compute_opening_balance(db, account, year, month)
+    total_income, total_expenses = _compute_month_totals(db, account_id, year, month)
+    closing = opening + total_income - total_expenses
+
+    return {
+        "account_id": account_id,
+        "account_name": account.name,
+        "year": year,
+        "month": month,
+        "opening_balance": opening,
+        "total_income": total_income,
+        "total_expenses": total_expenses,
+        "closing_balance": closing,
+        "is_closed": False,
+        "closed_at": None,
+    }
+
+
+def close_month(db: Session, account_id: int, year: int, month: int, user_id: int):
+    account = (
+        db.query(models.CashAccount)
+        .with_for_update()
+        .filter(models.CashAccount.id == account_id)
+        .first()
+    )
+    if not account:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="La cuenta no existe",
+        )
+
+    existing = (
+        db.query(models.CashMonthlyClosing)
+        .filter(
+            models.CashMonthlyClosing.account_id == account_id,
+            models.CashMonthlyClosing.year == year,
+            models.CashMonthlyClosing.month == month,
+            models.CashMonthlyClosing.is_closed.is_(True),
+        )
+        .first()
+    )
+    if existing:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Este mes ya se encuentra cerrado",
+        )
+
+    if month == 1:
+        prev_year, prev_month = year - 1, 12
+    else:
+        prev_year, prev_month = year, month - 1
+
+    earliest_movement = (
+        db.query(sa_func.min(models.CashMovement.movement_date))
+        .filter(models.CashMovement.account_id == account_id)
+        .scalar()
+    )
+
+    if earliest_movement:
+        earliest_year = earliest_movement.year
+        earliest_month = earliest_movement.month
+        prev_is_after_earliest = (prev_year > earliest_year) or (
+            prev_year == earliest_year and prev_month >= earliest_month
+        )
+
+        if prev_is_after_earliest:
+            prev_closing = (
+                db.query(models.CashMonthlyClosing)
+                .filter(
+                    models.CashMonthlyClosing.account_id == account_id,
+                    models.CashMonthlyClosing.year == prev_year,
+                    models.CashMonthlyClosing.month == prev_month,
+                    models.CashMonthlyClosing.is_closed.is_(True),
+                )
+                .first()
+            )
+            if not prev_closing:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"Debe cerrar el mes anterior ({prev_month:02d}/{prev_year}) primero",
+                )
+
+    opening = _compute_opening_balance(db, account, year, month)
+    total_income, total_expenses = _compute_month_totals(db, account_id, year, month)
+    closing_balance = opening + total_income - total_expenses
+
+    closing = models.CashMonthlyClosing(
+        account_id=account_id,
+        year=year,
+        month=month,
+        opening_balance=opening,
+        total_income=total_income,
+        total_expenses=total_expenses,
+        closing_balance=closing_balance,
+        is_closed=True,
+        closed_at=sa_func.now(),
+        closed_by_user_id=user_id,
+    )
+
+    db.add(closing)
+    db.commit()
+    db.refresh(closing)
+    return closing
+
+
+def list_closings(db: Session, account_id: int):
+    return (
+        db.query(models.CashMonthlyClosing)
+        .filter(models.CashMonthlyClosing.account_id == account_id)
+        .order_by(
+            models.CashMonthlyClosing.year.desc(),
+            models.CashMonthlyClosing.month.desc(),
+        )
+        .all()
+    )

--- a/frontend/src/features/cash-flow/components/MonthlyClosingPanel.tsx
+++ b/frontend/src/features/cash-flow/components/MonthlyClosingPanel.tsx
@@ -1,0 +1,328 @@
+import { useState } from 'react';
+import { CalendarCheck, Lock, Unlock, AlertTriangle } from 'lucide-react';
+
+import type {
+  CashAccount,
+  MonthlyClosing,
+  MonthlySummary,
+} from '../../../services/cashFlowService';
+import { currency } from '../types';
+
+const MONTH_NAMES = [
+  'Enero',
+  'Febrero',
+  'Marzo',
+  'Abril',
+  'Mayo',
+  'Junio',
+  'Julio',
+  'Agosto',
+  'Septiembre',
+  'Octubre',
+  'Noviembre',
+  'Diciembre',
+];
+
+interface MonthlyClosingPanelProps {
+  accounts: CashAccount[];
+  selectedAccountId: string;
+  setSelectedAccountId: (id: string) => void;
+  year: number;
+  setYear: (y: number) => void;
+  month: number;
+  setMonth: (m: number) => void;
+  summary: MonthlySummary | null;
+  closings: MonthlyClosing[];
+  loading: boolean;
+  closing: boolean;
+  error: string | null;
+  onCloseMonth: () => Promise<void>;
+}
+
+export default function MonthlyClosingPanel({
+  accounts,
+  selectedAccountId,
+  setSelectedAccountId,
+  year,
+  setYear,
+  month,
+  setMonth,
+  summary,
+  closings,
+  loading,
+  closing,
+  error,
+  onCloseMonth,
+}: MonthlyClosingPanelProps) {
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  const handleConfirmClose = async () => {
+    await onCloseMonth();
+    setShowConfirm(false);
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Selectores */}
+      <section className="rounded-2xl border border-neutral-border bg-neutral-surface p-5 shadow-sm">
+        <div className="flex items-center gap-2 mb-4 text-neutral-text">
+          <CalendarCheck size={18} />
+          <h2 className="text-sm font-semibold">Cierre Mensual</h2>
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          <div>
+            <label
+              htmlFor="closing-account"
+              className="block text-xs font-semibold text-neutral-muted mb-1"
+            >
+              Cuenta
+            </label>
+            <select
+              id="closing-account"
+              value={selectedAccountId}
+              onChange={(e) => setSelectedAccountId(e.target.value)}
+              className="w-full rounded-lg border border-neutral-border bg-white px-3 py-2 text-sm text-neutral-text"
+            >
+              {accounts.map((account) => (
+                <option key={account.id} value={String(account.id)}>
+                  {account.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label
+              htmlFor="closing-year"
+              className="block text-xs font-semibold text-neutral-muted mb-1"
+            >
+              Ano
+            </label>
+            <input
+              id="closing-year"
+              type="number"
+              min={2020}
+              max={2100}
+              value={year}
+              onChange={(e) => setYear(Number(e.target.value))}
+              className="w-full rounded-lg border border-neutral-border bg-white px-3 py-2 text-sm text-neutral-text"
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="closing-month"
+              className="block text-xs font-semibold text-neutral-muted mb-1"
+            >
+              Mes
+            </label>
+            <select
+              id="closing-month"
+              value={month}
+              onChange={(e) => setMonth(Number(e.target.value))}
+              className="w-full rounded-lg border border-neutral-border bg-white px-3 py-2 text-sm text-neutral-text"
+            >
+              {MONTH_NAMES.map((name, i) => (
+                <option key={i + 1} value={i + 1}>
+                  {name}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      </section>
+
+      {/* Error */}
+      {error && (
+        <div className="rounded-2xl border border-danger/30 bg-danger/5 p-4 text-center">
+          <p className="text-sm font-semibold text-danger">{error}</p>
+        </div>
+      )}
+
+      {/* Loading */}
+      {loading && (
+        <div className="rounded-2xl border border-neutral-border bg-neutral-surface p-6 text-center animate-pulse">
+          <p className="text-sm text-neutral-muted">Cargando resumen...</p>
+        </div>
+      )}
+
+      {/* Resumen mensual */}
+      {!loading && summary && (
+        <section className="rounded-2xl border border-neutral-border bg-neutral-surface p-5 shadow-sm">
+          <div className="flex items-center justify-between mb-4">
+            <h3 className="text-sm font-semibold text-neutral-text">
+              Resumen: {MONTH_NAMES[summary.month - 1]} {summary.year} -{' '}
+              {summary.account_name}
+            </h3>
+            <span
+              className={`inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-bold ${
+                summary.is_closed
+                  ? 'bg-emerald-100 text-emerald-700'
+                  : 'bg-amber-100 text-amber-700'
+              }`}
+            >
+              {summary.is_closed ? (
+                <>
+                  <Lock size={12} /> Cerrado
+                </>
+              ) : (
+                <>
+                  <Unlock size={12} /> Abierto
+                </>
+              )}
+            </span>
+          </div>
+
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+            <div className="rounded-xl border border-neutral-border p-3 bg-white">
+              <p className="text-xs text-neutral-muted">Saldo inicial</p>
+              <p className="text-lg font-bold text-neutral-text">
+                {currency.format(Number(summary.opening_balance))}
+              </p>
+            </div>
+            <div className="rounded-xl border border-neutral-border p-3 bg-white">
+              <p className="text-xs text-neutral-muted">Ingresos</p>
+              <p className="text-lg font-bold text-emerald-600">
+                +{currency.format(Number(summary.total_income))}
+              </p>
+            </div>
+            <div className="rounded-xl border border-neutral-border p-3 bg-white">
+              <p className="text-xs text-neutral-muted">Egresos</p>
+              <p className="text-lg font-bold text-red-600">
+                -{currency.format(Number(summary.total_expenses))}
+              </p>
+            </div>
+            <div className="rounded-xl border border-primary/30 p-3 bg-primary/5">
+              <p className="text-xs text-neutral-muted">Saldo de cierre</p>
+              <p className="text-lg font-bold text-primary">
+                {currency.format(Number(summary.closing_balance))}
+              </p>
+            </div>
+          </div>
+
+          {/* Boton cerrar mes */}
+          {!summary.is_closed && (
+            <div className="mt-4">
+              {!showConfirm ? (
+                <button
+                  type="button"
+                  onClick={() => setShowConfirm(true)}
+                  className="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-primary/90"
+                >
+                  <Lock size={14} />
+                  Cerrar Mes
+                </button>
+              ) : (
+                <div className="rounded-xl border border-amber-300 bg-amber-50 p-4">
+                  <div className="flex items-start gap-2 mb-3">
+                    <AlertTriangle
+                      size={16}
+                      className="text-amber-600 mt-0.5"
+                    />
+                    <div>
+                      <p className="text-sm font-semibold text-amber-800">
+                        Esta accion es irreversible
+                      </p>
+                      <p className="text-xs text-amber-700 mt-1">
+                        Se bloqueara {MONTH_NAMES[summary.month - 1]}{' '}
+                        {summary.year} para la cuenta {summary.account_name}. No
+                        se podran registrar movimientos en este periodo.
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex gap-2">
+                    <button
+                      type="button"
+                      onClick={handleConfirmClose}
+                      disabled={closing}
+                      className="rounded-lg bg-primary px-3 py-1.5 text-xs font-semibold text-white transition hover:bg-primary/90 disabled:opacity-50"
+                    >
+                      {closing ? 'Cerrando...' : 'Confirmar cierre'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setShowConfirm(false)}
+                      className="rounded-lg border border-neutral-border px-3 py-1.5 text-xs font-semibold text-neutral-text transition hover:bg-neutral-bg"
+                    >
+                      Cancelar
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
+          {summary.is_closed && summary.closed_at && (
+            <p className="mt-3 text-xs text-neutral-muted">
+              Cerrado el{' '}
+              {new Intl.DateTimeFormat('es-CO', {
+                day: '2-digit',
+                month: 'long',
+                year: 'numeric',
+                hour: '2-digit',
+                minute: '2-digit',
+              }).format(new Date(summary.closed_at))}
+            </p>
+          )}
+        </section>
+      )}
+
+      {/* Historial de cierres */}
+      {closings.length > 0 && (
+        <section className="rounded-2xl border border-neutral-border bg-neutral-surface p-5 shadow-sm">
+          <h3 className="text-sm font-semibold text-neutral-text mb-3">
+            Historial de cierres
+          </h3>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-neutral-border text-left text-xs text-neutral-muted">
+                  <th className="pb-2 pr-3">Periodo</th>
+                  <th className="pb-2 pr-3">Saldo inicial</th>
+                  <th className="pb-2 pr-3">Ingresos</th>
+                  <th className="pb-2 pr-3">Egresos</th>
+                  <th className="pb-2 pr-3">Saldo cierre</th>
+                  <th className="pb-2">Fecha cierre</th>
+                </tr>
+              </thead>
+              <tbody>
+                {closings.map((c) => (
+                  <tr
+                    key={c.id}
+                    className="border-b border-neutral-border/50 last:border-0"
+                  >
+                    <td className="py-2 pr-3 font-medium text-neutral-text">
+                      {MONTH_NAMES[c.month - 1]} {c.year}
+                    </td>
+                    <td className="py-2 pr-3">
+                      {currency.format(Number(c.opening_balance))}
+                    </td>
+                    <td className="py-2 pr-3 text-emerald-600">
+                      +{currency.format(Number(c.total_income))}
+                    </td>
+                    <td className="py-2 pr-3 text-red-600">
+                      -{currency.format(Number(c.total_expenses))}
+                    </td>
+                    <td className="py-2 pr-3 font-bold text-primary">
+                      {currency.format(Number(c.closing_balance))}
+                    </td>
+                    <td className="py-2 text-neutral-muted">
+                      {c.closed_at
+                        ? new Intl.DateTimeFormat('es-CO', {
+                            day: '2-digit',
+                            month: 'short',
+                            year: 'numeric',
+                          }).format(new Date(c.closed_at))
+                        : '-'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/cash-flow/hooks/useMonthlyClosing.ts
+++ b/frontend/src/features/cash-flow/hooks/useMonthlyClosing.ts
@@ -1,0 +1,117 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import {
+  closeMonth,
+  getMonthlyClosings,
+  getMonthlySummary,
+} from '../../../services/cashFlowService';
+import type {
+  CashAccount,
+  MonthlyClosing,
+  MonthlySummary,
+} from '../../../services/cashFlowService';
+
+const getDefaultPeriod = () => {
+  const now = new Date();
+  const prevMonth = now.getMonth(); // 0-based, so current month - 1
+  const year = prevMonth === 0 ? now.getFullYear() - 1 : now.getFullYear();
+  const month = prevMonth === 0 ? 12 : prevMonth;
+  return { year, month };
+};
+
+interface UseMonthlyClosingParams {
+  accounts: CashAccount[];
+}
+
+export const useMonthlyClosing = ({ accounts }: UseMonthlyClosingParams) => {
+  const defaults = getDefaultPeriod();
+
+  const [selectedAccountId, setSelectedAccountId] = useState<string>('');
+  const [year, setYear] = useState(defaults.year);
+  const [month, setMonth] = useState(defaults.month);
+  const [summary, setSummary] = useState<MonthlySummary | null>(null);
+  const [closings, setClosings] = useState<MonthlyClosing[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [closing, setClosing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (accounts.length > 0 && !selectedAccountId) {
+      setSelectedAccountId(String(accounts[0].id));
+    }
+  }, [accounts, selectedAccountId]);
+
+  const fetchSummary = useCallback(async () => {
+    const accountId = Number(selectedAccountId);
+    if (!accountId || !year || !month) return;
+
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await getMonthlySummary(accountId, year, month);
+      setSummary(data);
+    } catch {
+      setError('No se pudo cargar el resumen mensual.');
+      setSummary(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [selectedAccountId, year, month]);
+
+  const fetchClosings = useCallback(async () => {
+    const accountId = Number(selectedAccountId);
+    if (!accountId) return;
+
+    try {
+      const data = await getMonthlyClosings(accountId);
+      setClosings(data);
+    } catch {
+      setClosings([]);
+    }
+  }, [selectedAccountId]);
+
+  useEffect(() => {
+    fetchSummary();
+  }, [fetchSummary]);
+
+  useEffect(() => {
+    fetchClosings();
+  }, [fetchClosings]);
+
+  const handleCloseMonth = useCallback(async () => {
+    const accountId = Number(selectedAccountId);
+    if (!accountId) return;
+
+    setClosing(true);
+    setError(null);
+    try {
+      await closeMonth(accountId, year, month);
+      await fetchSummary();
+      await fetchClosings();
+    } catch (err: unknown) {
+      const detail =
+        err instanceof Object && 'response' in err
+          ? (err as { response?: { data?: { detail?: string } } }).response
+              ?.data?.detail
+          : undefined;
+      setError(detail ?? 'No se pudo cerrar el mes.');
+    } finally {
+      setClosing(false);
+    }
+  }, [selectedAccountId, year, month, fetchSummary, fetchClosings]);
+
+  return {
+    selectedAccountId,
+    setSelectedAccountId,
+    year,
+    setYear,
+    month,
+    setMonth,
+    summary,
+    closings,
+    loading,
+    closing,
+    error,
+    handleCloseMonth,
+  };
+};

--- a/frontend/src/pages/CashFlowPage.tsx
+++ b/frontend/src/pages/CashFlowPage.tsx
@@ -1,12 +1,20 @@
+import { useState } from 'react';
+
 import CashFlowSkeleton from '../features/cash-flow/components/CashFlowSkeleton';
 import CashFlowSummary from '../features/cash-flow/components/CashFlowSummary';
 import CashFlowToasts from '../features/cash-flow/components/CashFlowToasts';
+import MonthlyClosingPanel from '../features/cash-flow/components/MonthlyClosingPanel';
 import MovementsTimeline from '../features/cash-flow/components/MovementsTimeline';
 import NewAccountCard from '../features/cash-flow/components/NewAccountCard';
 import NewMovementCard from '../features/cash-flow/components/NewMovementCard';
 import { useCashFlowData } from '../features/cash-flow/hooks/useCashFlowData';
+import { useMonthlyClosing } from '../features/cash-flow/hooks/useMonthlyClosing';
+
+type ActiveTab = 'movements' | 'monthly';
 
 export default function CashFlowPage() {
+  const [activeTab, setActiveTab] = useState<ActiveTab>('movements');
+
   const {
     accounts,
     movements,
@@ -31,6 +39,8 @@ export default function CashFlowPage() {
     handleCreateMovement,
   } = useCashFlowData();
 
+  const monthlyClosing = useMonthlyClosing({ accounts });
+
   return (
     <div className="min-h-screen bg-neutral-bg px-6 py-8">
       <div className="max-w-7xl mx-auto space-y-6">
@@ -46,9 +56,43 @@ export default function CashFlowPage() {
           </p>
         </header>
 
+        {/* Tabs */}
+        <div
+          role="tablist"
+          aria-label="Secciones del flujo de caja"
+          className="inline-flex rounded-xl border border-neutral-border bg-white p-1"
+        >
+          <button
+            type="button"
+            role="tab"
+            aria-selected={activeTab === 'movements'}
+            onClick={() => setActiveTab('movements')}
+            className={`rounded-lg px-4 py-2 text-sm font-semibold transition ${
+              activeTab === 'movements'
+                ? 'bg-primary text-white'
+                : 'text-neutral-muted hover:text-neutral-text'
+            }`}
+          >
+            Movimientos
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={activeTab === 'monthly'}
+            onClick={() => setActiveTab('monthly')}
+            className={`rounded-lg px-4 py-2 text-sm font-semibold transition ${
+              activeTab === 'monthly'
+                ? 'bg-primary text-white'
+                : 'text-neutral-muted hover:text-neutral-text'
+            }`}
+          >
+            Cierre Mensual
+          </button>
+        </div>
+
         {loading ? (
           <CashFlowSkeleton />
-        ) : (
+        ) : activeTab === 'movements' ? (
           <>
             <CashFlowSummary accounts={accounts} totalBalance={totalBalance} />
 
@@ -82,6 +126,22 @@ export default function CashFlowPage() {
               loading={loading}
             />
           </>
+        ) : (
+          <MonthlyClosingPanel
+            accounts={accounts}
+            selectedAccountId={monthlyClosing.selectedAccountId}
+            setSelectedAccountId={monthlyClosing.setSelectedAccountId}
+            year={monthlyClosing.year}
+            setYear={monthlyClosing.setYear}
+            month={monthlyClosing.month}
+            setMonth={monthlyClosing.setMonth}
+            summary={monthlyClosing.summary}
+            closings={monthlyClosing.closings}
+            loading={monthlyClosing.loading}
+            closing={monthlyClosing.closing}
+            error={monthlyClosing.error}
+            onCloseMonth={monthlyClosing.handleCloseMonth}
+          />
         )}
       </div>
     </div>

--- a/frontend/src/services/cashFlowService.ts
+++ b/frontend/src/services/cashFlowService.ts
@@ -60,3 +60,63 @@ export const createCashMovement = async (
   const response = await api.post('/cash-flow/movements', payload);
   return response.data;
 };
+
+export interface MonthlySummary {
+  account_id: number;
+  account_name: string;
+  year: number;
+  month: number;
+  opening_balance: string;
+  total_income: string;
+  total_expenses: string;
+  closing_balance: string;
+  is_closed: boolean;
+  closed_at: string | null;
+}
+
+export interface MonthlyClosing {
+  id: number;
+  account_id: number;
+  year: number;
+  month: number;
+  opening_balance: string;
+  total_income: string;
+  total_expenses: string;
+  closing_balance: string;
+  is_closed: boolean;
+  closed_at: string | null;
+  created_at: string;
+}
+
+export const getMonthlySummary = async (
+  accountId: number,
+  year: number,
+  month: number
+): Promise<MonthlySummary> => {
+  const response = await api.get('/cash-flow/monthly-summary', {
+    params: { account_id: accountId, year, month },
+  });
+  return response.data;
+};
+
+export const closeMonth = async (
+  accountId: number,
+  year: number,
+  month: number
+): Promise<MonthlyClosing> => {
+  const response = await api.post('/cash-flow/monthly-close', {
+    account_id: accountId,
+    year,
+    month,
+  });
+  return response.data;
+};
+
+export const getMonthlyClosings = async (
+  accountId: number
+): Promise<MonthlyClosing[]> => {
+  const response = await api.get('/cash-flow/monthly-closings', {
+    params: { account_id: accountId },
+  });
+  return response.data;
+};


### PR DESCRIPTION
## Objetivo

  Implementar el cierre mensual de caja que permita consolidar y bloquear periodos contables, garantizando la integridad de los saldos y la secuencia cronológica de los cierres.

### Cambios Principales

  - Modelo CashMonthlyClosing: nueva tabla con saldo inicial, ingresos, egresos, saldo de cierre, estado y fecha de cierre (constraint único por cuenta/año/mes)
  - Migración Alembic: a1b2c3d4e5f6_create_cash_monthly_closings
  - Endpoints:
    - GET /cash-flow/monthly-summary — resumen calculado del mes (abierto o cerrado)
    - POST /cash-flow/monthly-close — cierre irreversible con validaciones
    - GET /cash-flow/monthly-closings — historial de cierres por cuenta
  - Validaciones backend:
    - Cierre secuencial obligatorio (no se puede saltar meses)
    - Bloqueo de movimientos en meses cerrados
    - Arrastre automático de saldos entre periodos
  - Frontend:
    - Nuevo tab "Cierre Mensual" en /flujo-de-caja
    - Panel con selectores de cuenta, año y mes (default: mes anterior)
    - Resumen con 4 tarjetas: saldo inicial, ingresos, egresos, saldo de cierre
    - Badge de estado (Abierto/Cerrado)
    - Confirmación con advertencia irreversible antes de cerrar
    - Tabla de historial de cierres
    - Hook useMonthlyClosing para gestionar estado y llamadas API

## Como probarlo

  Pre-requisito: tener al menos 1 cuenta de caja con movimientos registrados.

  1. Navegar a /flujo-de-caja y verificar los tabs "Movimientos" y "Cierre Mensual"
  2. Click en "Cierre Mensual" — verificar selectores, resumen y badge "Abierto"
  3. Cambiar mes/cuenta — montos deben actualizarse ($0 en meses sin movimientos)
  4. Cerrar el mes mas antiguo con movimientos — verificar advertencia, cancelar, confirmar, badge "Cerrado" e historial
  5. Seleccionar el mes siguiente — el saldo inicial debe coincidir con el saldo de cierre del mes cerrado
  6. Intentar cerrar un mes saltando uno — debe mostrar error "Debe cerrar el mes anterior primero"
  7. En tab "Movimientos", crear movimiento con fecha en mes cerrado — debe rechazarse
  8. Crear movimiento en mes abierto — debe funcionar normalmente

## Notas Adicionales

  - El cierre es irreversible por diseño (requisito contable)
  - El saldo inicial se calcula desde el cierre anterior si existe, o se deriva del historial de movimientos si no hay cierres previos
  - No se modificó la lógica existente de movimientos ni cuentas (sin regresiones)