### PR TITLE
feat: restringir acceso a flujo de caja 

### DIFF
--- a/backend/src/modules/cole_co/cash_flow/router.py
+++ b/backend/src/modules/cole_co/cash_flow/router.py
@@ -11,6 +11,7 @@ router = APIRouter(prefix="/cash-flow", tags=["Cash Flow"])
 
 ALLOWED_ROLES = [
     auth_models.UserRole.ADMIN,
+    auth_models.UserRole.CONTADOR_COLE_CO,
 ]
 
 

--- a/backend/src/modules/cole_co/cash_flow/router.py
+++ b/backend/src/modules/cole_co/cash_flow/router.py
@@ -11,7 +11,6 @@ router = APIRouter(prefix="/cash-flow", tags=["Cash Flow"])
 
 ALLOWED_ROLES = [
     auth_models.UserRole.ADMIN,
-    auth_models.UserRole.CONTADOR_COLE_CO,
 ]
 
 

--- a/backend/tests/test_cash_flow_router.py
+++ b/backend/tests/test_cash_flow_router.py
@@ -5,8 +5,14 @@ from src.modules.cole_co.cash_flow import router
 
 
 class CashFlowRouterRoleTests(unittest.TestCase):
-    def test_cash_flow_is_restricted_to_admin_role(self):
-        self.assertEqual(router.ALLOWED_ROLES, [auth_models.UserRole.ADMIN])
+    def test_cash_flow_allows_admin_and_cole_co_accountant(self):
+        self.assertEqual(
+            router.ALLOWED_ROLES,
+            [
+                auth_models.UserRole.ADMIN,
+                auth_models.UserRole.CONTADOR_COLE_CO,
+            ],
+        )
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_cash_flow_router.py
+++ b/backend/tests/test_cash_flow_router.py
@@ -1,0 +1,13 @@
+import unittest
+
+from src.modules.auth import models as auth_models
+from src.modules.cole_co.cash_flow import router
+
+
+class CashFlowRouterRoleTests(unittest.TestCase):
+    def test_cash_flow_is_restricted_to_admin_role(self):
+        self.assertEqual(router.ALLOWED_ROLES, [auth_models.UserRole.ADMIN])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import React from 'react';
 import SettingsPage from './pages/SettingsPage';
 import NotificationsPage from './pages/NotificationsPage';
 import CashFlowPage from './pages/CashFlowPage';
+import { CASH_FLOW_ALLOWED_ROLES } from './constants/authorization';
 
 function LayoutWithSidebar({ children }: { children: React.ReactNode }) {
   return (
@@ -64,7 +65,7 @@ function App() {
         <Route
           path="/flujo-de-caja"
           element={
-            <ProtectedRoute>
+            <ProtectedRoute allowedRoles={CASH_FLOW_ALLOWED_ROLES}>
               <LayoutWithSidebar>
                 <CashFlowPage />
               </LayoutWithSidebar>

--- a/frontend/src/__tests__/ProtectedRoute.test.tsx
+++ b/frontend/src/__tests__/ProtectedRoute.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { ProtectedRoute } from '../components/ProtectedRoute';
+import { AuthContext } from '../context/AuthContext';
+import type { UserProfile } from '../services/authService';
+
+const baseUser: UserProfile = {
+  id: 1,
+  email: 'qa@conexia.com',
+  full_name: 'QA Analyst',
+  role: 'contador_cole_co',
+  is_active: true,
+  must_change_password: false,
+  alert_deadlines_enabled: true,
+  alert_balances_enabled: false,
+  alert_reports_enabled: false,
+  reminder_window_start_days: 5,
+  reminder_window_end_days: 7,
+};
+
+function renderProtectedRoute(user: UserProfile) {
+  render(
+    <AuthContext.Provider
+      value={{
+        user,
+        isAuthenticated: true,
+        loading: false,
+        loginState: vi.fn(),
+        logout: vi.fn(),
+        refreshUser: vi.fn(),
+        patchUser: vi.fn(),
+        setUser: vi.fn(),
+      }}
+    >
+      <MemoryRouter initialEntries={['/flujo-de-caja']}>
+        <Routes>
+          <Route
+            path="/flujo-de-caja"
+            element={
+              <ProtectedRoute allowedRoles={['admin']}>
+                <div>Vista privada</div>
+              </ProtectedRoute>
+            }
+          />
+          <Route path="/dashboard" element={<div>Dashboard</div>} />
+        </Routes>
+      </MemoryRouter>
+    </AuthContext.Provider>
+  );
+}
+
+describe('ProtectedRoute', () => {
+  it('redirige al dashboard cuando el rol no esta autorizado', () => {
+    renderProtectedRoute(baseUser);
+
+    expect(screen.getByText('Dashboard')).toBeInTheDocument();
+    expect(screen.queryByText('Vista privada')).not.toBeInTheDocument();
+  });
+
+  it('permite el acceso cuando el rol esta autorizado', () => {
+    renderProtectedRoute({
+      ...baseUser,
+      role: 'admin',
+    });
+
+    expect(screen.getByText('Vista privada')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/SettingsPage.test.tsx
+++ b/frontend/src/__tests__/SettingsPage.test.tsx
@@ -26,7 +26,6 @@ const baseUser: UserProfile = {
 };
 
 function renderPage(user: UserProfile = baseUser) {
-  const patchUser = vi.fn();
   const setUser = vi.fn();
   const refreshUser = vi.fn().mockResolvedValue(undefined);
 
@@ -39,7 +38,7 @@ function renderPage(user: UserProfile = baseUser) {
         loginState: vi.fn(),
         logout: vi.fn(),
         refreshUser,
-        patchUser,
+        patchUser: vi.fn(),
         setUser,
       }}
     >
@@ -47,7 +46,7 @@ function renderPage(user: UserProfile = baseUser) {
     </AuthContext.Provider>
   );
 
-  return { patchUser, setUser, refreshUser };
+  return { setUser, refreshUser };
 }
 
 describe('SettingsPage', () => {
@@ -63,17 +62,17 @@ describe('SettingsPage', () => {
     expect(screen.getByText(/contador family office/i)).toBeInTheDocument();
   });
 
-  it('permite alternar las alertas desde el perfil', async () => {
+  it('permite alternar las alertas desde el perfil antes de guardar', async () => {
     const user = userEvent.setup();
-    const { patchUser } = renderPage();
+    renderPage();
 
     await user.click(
-      screen.getByRole('button', { name: /alternar alertas de vencimientos/i })
+      screen.getByRole('switch', { name: /alertas de vencimientos/i })
     );
 
-    expect(patchUser).toHaveBeenCalledWith({
-      alert_deadlines_enabled: false,
-    });
+    expect(
+      screen.getByRole('switch', { name: /alertas de vencimientos/i })
+    ).toHaveAttribute('aria-checked', 'false');
   });
 
   it('guarda los cambios del perfil y muestra confirmacion', async () => {
@@ -88,6 +87,7 @@ describe('SettingsPage', () => {
     const nameInput = screen.getByDisplayValue('QA Analyst');
     await user.clear(nameInput);
     await user.type(nameInput, 'QA Lead');
+    await user.click(screen.getByRole('switch', { name: /alertas de reportes/i }));
     await user.click(screen.getByRole('button', { name: /guardar cambios/i }));
 
     await waitFor(() => {
@@ -96,7 +96,7 @@ describe('SettingsPage', () => {
         email: 'qa@conexia.com',
         alert_deadlines_enabled: true,
         alert_balances_enabled: true,
-        alert_reports_enabled: false,
+        alert_reports_enabled: true,
         reminder_window_start_days: 5,
         reminder_window_end_days: 7,
       });

--- a/frontend/src/__tests__/SettingsPage.test.tsx
+++ b/frontend/src/__tests__/SettingsPage.test.tsx
@@ -87,7 +87,9 @@ describe('SettingsPage', () => {
     const nameInput = screen.getByDisplayValue('QA Analyst');
     await user.clear(nameInput);
     await user.type(nameInput, 'QA Lead');
-    await user.click(screen.getByRole('switch', { name: /alertas de reportes/i }));
+    await user.click(
+      screen.getByRole('switch', { name: /alertas de reportes/i })
+    );
     await user.click(screen.getByRole('button', { name: /guardar cambios/i }));
 
     await waitFor(() => {

--- a/frontend/src/__tests__/Sidebar.test.tsx
+++ b/frontend/src/__tests__/Sidebar.test.tsx
@@ -49,11 +49,11 @@ describe('Sidebar', () => {
 
     expect(screen.getByText('Dashboard')).toBeInTheDocument();
     expect(screen.queryByText('Family Office')).not.toBeInTheDocument();
-    expect(screen.queryByText('Flujo de Caja')).not.toBeInTheDocument();
+    expect(screen.getByText('Flujo de Caja')).toBeInTheDocument();
     expect(screen.queryByText('Notificaciones')).not.toBeInTheDocument();
   });
 
-  it('muestra flujo de caja solo al administrador', () => {
+  it('muestra flujo de caja al administrador', () => {
     renderSidebar({
       ...baseUser,
       role: 'admin',

--- a/frontend/src/__tests__/Sidebar.test.tsx
+++ b/frontend/src/__tests__/Sidebar.test.tsx
@@ -49,7 +49,17 @@ describe('Sidebar', () => {
 
     expect(screen.getByText('Dashboard')).toBeInTheDocument();
     expect(screen.queryByText('Family Office')).not.toBeInTheDocument();
+    expect(screen.queryByText('Flujo de Caja')).not.toBeInTheDocument();
     expect(screen.queryByText('Notificaciones')).not.toBeInTheDocument();
+  });
+
+  it('muestra flujo de caja solo al administrador', () => {
+    renderSidebar({
+      ...baseUser,
+      role: 'admin',
+    });
+
+    expect(screen.getByText('Flujo de Caja')).toBeInTheDocument();
   });
 
   it('oculta notificaciones cuando todas las alertas estan desactivadas', () => {
@@ -61,6 +71,30 @@ describe('Sidebar', () => {
     });
 
     expect(screen.queryByText('Notificaciones')).not.toBeInTheDocument();
+  });
+
+  it('muestra notificaciones cuando solo alertas de balances estan activas', () => {
+    renderSidebar({
+      ...baseUser,
+      role: 'contador_family_office',
+      alert_deadlines_enabled: false,
+      alert_balances_enabled: true,
+      alert_reports_enabled: false,
+    });
+
+    expect(screen.getByText('Notificaciones')).toBeInTheDocument();
+  });
+
+  it('muestra notificaciones cuando solo alertas de reportes estan activas', () => {
+    renderSidebar({
+      ...baseUser,
+      role: 'contador_family_office',
+      alert_deadlines_enabled: false,
+      alert_balances_enabled: false,
+      alert_reports_enabled: true,
+    });
+
+    expect(screen.getByText('Notificaciones')).toBeInTheDocument();
   });
 
   it('permite minimizar la barra lateral', async () => {

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -4,9 +4,10 @@ import { AuthContext } from '../context/AuthContext';
 
 interface Props {
   children: React.ReactNode;
+  allowedRoles?: readonly string[];
 }
 
-export const ProtectedRoute = ({ children }: Props) => {
+export const ProtectedRoute = ({ children, allowedRoles }: Props) => {
   const { isAuthenticated, user, loading } = useContext(AuthContext);
   const location = useLocation();
 
@@ -29,6 +30,10 @@ export const ProtectedRoute = ({ children }: Props) => {
   }
 
   if (!user?.must_change_password && location.pathname === '/change-password') {
+    return <Navigate to="/dashboard" replace />;
+  }
+
+  if (allowedRoles && (!user?.role || !allowedRoles.includes(user.role))) {
     return <Navigate to="/dashboard" replace />;
   }
 

--- a/frontend/src/components/ReportModal.tsx
+++ b/frontend/src/components/ReportModal.tsx
@@ -16,6 +16,9 @@ import type { Balance } from '../services/balanceService';
 import { generateReport, exportReportPDF } from '../services/reportService';
 import type { LineItem, ReportData } from '../services/reportService';
 import { useCompany } from '../context/CompanyContext';
+import { AuthContext } from '../context/AuthContext';
+import { useContext } from 'react';
+import { appendStoredNotificationEvent } from '../services/notificationEventService';
 
 interface Props {
   onClose: () => void;
@@ -27,6 +30,7 @@ type Step = 'select' | 'loading' | 'ready';
 
 export default function ReportModal({ onClose, balanceId, balances }: Props) {
   const { activeCompany } = useCompany();
+  const { user } = useContext(AuthContext);
   const [step, setStep] = useState<Step>(balanceId ? 'loading' : 'select');
   const [error, setError] = useState<string | null>(null);
 
@@ -72,6 +76,17 @@ export default function ReportModal({ onClose, balanceId, balances }: Props) {
       setAiSummary(data.ai_summary);
       setCompanyName(data.company_name);
       setPeriod(data.period);
+      if (user?.id) {
+        appendStoredNotificationEvent(user.id, {
+          id: `report-${selectedBalanceId}-${Date.now()}`,
+          type: 'report',
+          title: `Reporte generado: ${data.company_name}`,
+          message: `Se generó un resumen con IA para el periodo ${data.period}.`,
+          isoDate: new Date().toISOString(),
+          companyId: activeCompany?.id,
+          companyName: data.company_name,
+        });
+      }
       setStep('ready');
     } catch {
       setError(

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,6 +1,11 @@
 import { useContext } from 'react';
 import { NavLink, useNavigate } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext';
+import {
+  ADMIN_ROLE,
+  CASH_FLOW_ALLOWED_ROLES,
+  NOTIFICATIONS_ALLOWED_ROLES,
+} from '../constants/authorization';
 import { useCompany } from '../context/CompanyContext';
 import { useSidebar } from '../context/SidebarContext';
 import {
@@ -33,7 +38,7 @@ const mainItems = [
     label: 'Flujo de Caja',
     icon: ArrowLeftRight,
     path: '/flujo-de-caja',
-    roles: ['admin', 'contador_family_office', 'contador_cole_co'],
+    roles: [...CASH_FLOW_ALLOWED_ROLES],
   },
   {
     label: 'Facturas',
@@ -49,8 +54,6 @@ const mainItems = [
   },
 ];
 
-const NOTIFICATIONS_ALLOWED_ROLES = ['admin', 'contador_family_office'];
-
 export default function Sidebar() {
   const { isExpanded, toggle } = useSidebar();
   const { logout, user } = useContext(AuthContext);
@@ -59,7 +62,10 @@ export default function Sidebar() {
   const roleLabel = user?.role?.replaceAll('_', ' ');
   const hasNotificationsAccess =
     !!user?.role && NOTIFICATIONS_ALLOWED_ROLES.includes(user.role);
-  const hasEnabledAlerts = !!user?.alert_deadlines_enabled;
+  const hasEnabledAlerts =
+    !!user?.alert_deadlines_enabled ||
+    !!user?.alert_balances_enabled ||
+    !!user?.alert_reports_enabled;
   const canSeeNotifications = hasNotificationsAccess && hasEnabledAlerts;
 
   const handleLogout = () => {

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -2,7 +2,6 @@ import { useContext } from 'react';
 import { NavLink, useNavigate } from 'react-router-dom';
 import { AuthContext } from '../context/AuthContext';
 import {
-  ADMIN_ROLE,
   CASH_FLOW_ALLOWED_ROLES,
   NOTIFICATIONS_ALLOWED_ROLES,
 } from '../constants/authorization';

--- a/frontend/src/constants/authorization.ts
+++ b/frontend/src/constants/authorization.ts
@@ -1,6 +1,10 @@
 export const ADMIN_ROLE = 'admin';
+export const COLE_CO_ACCOUNTANT_ROLE = 'contador_cole_co';
 
-export const CASH_FLOW_ALLOWED_ROLES = [ADMIN_ROLE] as const;
+export const CASH_FLOW_ALLOWED_ROLES = [
+  ADMIN_ROLE,
+  COLE_CO_ACCOUNTANT_ROLE,
+] as const;
 
 export const NOTIFICATIONS_ALLOWED_ROLES = [
   ADMIN_ROLE,

--- a/frontend/src/constants/authorization.ts
+++ b/frontend/src/constants/authorization.ts
@@ -1,0 +1,8 @@
+export const ADMIN_ROLE = 'admin';
+
+export const CASH_FLOW_ALLOWED_ROLES = [ADMIN_ROLE] as const;
+
+export const NOTIFICATIONS_ALLOWED_ROLES = [
+  ADMIN_ROLE,
+  'contador_family_office',
+] as const;

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -72,9 +72,15 @@ export const useNotifications = ({
   companyIds,
   companyNameById = {},
 }: UseNotificationsParams) => {
-  const [deadlineSources, setDeadlineSources] = useState<DeadlineNotificationSource[]>([]);
-  const [balanceSources, setBalanceSources] = useState<BalanceNotificationSource[]>([]);
-  const [reportEvents, setReportEvents] = useState<StoredNotificationEvent[]>([]);
+  const [deadlineSources, setDeadlineSources] = useState<
+    DeadlineNotificationSource[]
+  >([]);
+  const [balanceSources, setBalanceSources] = useState<
+    BalanceNotificationSource[]
+  >([]);
+  const [reportEvents, setReportEvents] = useState<StoredNotificationEvent[]>(
+    []
+  );
   const [loading, setLoading] = useState(
     !!user?.alert_deadlines_enabled ||
       !!user?.alert_balances_enabled ||
@@ -166,7 +172,11 @@ export const useNotifications = ({
         const nextBalanceSources = shouldLoadBalances
           ? byCompany
               .flatMap(({ companyId, companyName, balancesData }) =>
-                balancesData.map((balance) => ({ companyId, companyName, balance }))
+                balancesData.map((balance) => ({
+                  companyId,
+                  companyName,
+                  balance,
+                }))
               )
               .sort((a, b) =>
                 compareByIsoDateDesc(

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -1,14 +1,24 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { UserProfile } from '../services/authService';
+import { getBalancesByCompany } from '../services/balanceService';
+import type { Balance } from '../services/balanceService';
 import { getDeadlinesByCompany } from '../services/deadlineService';
 import type { Deadline } from '../services/deadlineService';
+import { getStoredNotificationEvents } from '../services/notificationEventService';
+import type { StoredNotificationEvent } from '../services/notificationEventService';
 
-type NotificationType = 'deadline';
+type NotificationType = 'deadline' | 'balance' | 'report';
 
 interface DeadlineNotificationSource {
   companyId: number;
   companyName?: string;
   deadline: Deadline;
+}
+
+interface BalanceNotificationSource {
+  companyId: number;
+  companyName?: string;
+  balance: Balance;
 }
 
 export interface NotificationItem {
@@ -54,13 +64,22 @@ const compareByDueDateAsc = (a: Deadline, b: Deadline) => {
   return aTime - bTime;
 };
 
+const compareByIsoDateDesc = (a: { isoDate: string }, b: { isoDate: string }) =>
+  new Date(b.isoDate).getTime() - new Date(a.isoDate).getTime();
+
 export const useNotifications = ({
   user,
   companyIds,
   companyNameById = {},
 }: UseNotificationsParams) => {
-  const [sources, setSources] = useState<DeadlineNotificationSource[]>([]);
-  const [loading, setLoading] = useState(!!user?.alert_deadlines_enabled);
+  const [deadlineSources, setDeadlineSources] = useState<DeadlineNotificationSource[]>([]);
+  const [balanceSources, setBalanceSources] = useState<BalanceNotificationSource[]>([]);
+  const [reportEvents, setReportEvents] = useState<StoredNotificationEvent[]>([]);
+  const [loading, setLoading] = useState(
+    !!user?.alert_deadlines_enabled ||
+      !!user?.alert_balances_enabled ||
+      !!user?.alert_reports_enabled
+  );
   const [error, setError] = useState<string | null>(null);
   const [reloadKey, setReloadKey] = useState(0);
   const [readIds, setReadIds] = useState<string[]>(() => {
@@ -91,9 +110,15 @@ export const useNotifications = ({
 
   useEffect(() => {
     const shouldLoadDeadlines = !!user?.alert_deadlines_enabled;
+    const shouldLoadBalances = !!user?.alert_balances_enabled;
+    const shouldLoadReports = !!user?.alert_reports_enabled;
+    const shouldLoadAnyAlerts =
+      shouldLoadDeadlines || shouldLoadBalances || shouldLoadReports;
 
-    if (!shouldLoadDeadlines || companyIds.length === 0) {
-      setSources([]);
+    if (!shouldLoadAnyAlerts) {
+      setDeadlineSources([]);
+      setBalanceSources([]);
+      setReportEvents([]);
       setLoading(false);
       setError(null);
       return;
@@ -105,31 +130,74 @@ export const useNotifications = ({
       setLoading(true);
       setError(null);
       try {
-        const byCompany = await Promise.all(
-          companyIds.map(async (companyId) => {
-            const deadlinesData = await getDeadlinesByCompany(companyId);
-            return {
-              companyId,
-              companyName: companyNameById[companyId],
-              deadlinesData,
-            };
-          })
-        );
+        const byCompany =
+          companyIds.length > 0
+            ? await Promise.all(
+                companyIds.map(async (companyId) => {
+                  const [deadlinesData, balancesData] = await Promise.all([
+                    shouldLoadDeadlines
+                      ? getDeadlinesByCompany(companyId)
+                      : Promise.resolve([]),
+                    shouldLoadBalances
+                      ? getBalancesByCompany(companyId)
+                      : Promise.resolve([]),
+                  ]);
 
-        const mergedSources = byCompany
-          .flatMap(({ companyId, companyName, deadlinesData }) =>
-            deadlinesData
-              .filter((item) => item.status === 'pendiente')
-              .map((deadline) => ({ companyId, companyName, deadline }))
-          )
-          .sort((a, b) => compareByDueDateAsc(a.deadline, b.deadline));
+                  return {
+                    companyId,
+                    companyName: companyNameById[companyId],
+                    deadlinesData,
+                    balancesData,
+                  };
+                })
+              )
+            : [];
+
+        const nextDeadlineSources = shouldLoadDeadlines
+          ? byCompany
+              .flatMap(({ companyId, companyName, deadlinesData }) =>
+                deadlinesData
+                  .filter((item) => item.status === 'pendiente')
+                  .map((deadline) => ({ companyId, companyName, deadline }))
+              )
+              .sort((a, b) => compareByDueDateAsc(a.deadline, b.deadline))
+          : [];
+
+        const nextBalanceSources = shouldLoadBalances
+          ? byCompany
+              .flatMap(({ companyId, companyName, balancesData }) =>
+                balancesData.map((balance) => ({ companyId, companyName, balance }))
+              )
+              .sort((a, b) =>
+                compareByIsoDateDesc(
+                  { isoDate: a.balance.uploaded_at },
+                  { isoDate: b.balance.uploaded_at }
+                )
+              )
+          : [];
+
+        const nextReportEvents =
+          shouldLoadReports && user?.id
+            ? getStoredNotificationEvents(user.id)
+                .filter(
+                  (event) =>
+                    !event.companyId ||
+                    companyIds.length === 0 ||
+                    companyIds.includes(event.companyId)
+                )
+                .sort(compareByIsoDateDesc)
+            : [];
 
         if (!ignore) {
-          setSources(mergedSources);
+          setDeadlineSources(nextDeadlineSources);
+          setBalanceSources(nextBalanceSources);
+          setReportEvents(nextReportEvents);
         }
       } catch {
         if (!ignore) {
-          setSources([]);
+          setDeadlineSources([]);
+          setBalanceSources([]);
+          setReportEvents([]);
           setError('No se pudieron cargar las notificaciones.');
         }
       } finally {
@@ -144,26 +212,70 @@ export const useNotifications = ({
     return () => {
       ignore = true;
     };
-  }, [companyIds, companyNameById, reloadKey, user?.alert_deadlines_enabled]);
+  }, [
+    companyIds,
+    companyNameById,
+    reloadKey,
+    user?.alert_deadlines_enabled,
+    user?.alert_balances_enabled,
+    user?.alert_reports_enabled,
+    user?.id,
+  ]);
 
   const notifications = useMemo<NotificationItem[]>(() => {
-    return sources.map(({ companyId, companyName, deadline }) => {
-      const id = `deadline-${companyId}-${deadline.id}`;
+    const deadlineNotifications = deadlineSources.map(
+      ({ companyId, companyName, deadline }) => {
+        const id = `deadline-${companyId}-${deadline.id}`;
 
-      const companyLabel = companyName ? `Empresa: ${companyName}. ` : '';
+        const companyLabel = companyName ? `Empresa: ${companyName}. ` : '';
 
-      return {
-        id,
-        title: `Vencimiento: ${deadline.name}`,
-        message: `${companyLabel}${deadline.description || 'Revisa y gestiona este compromiso a tiempo.'}`,
-        isoDate: deadline.due_date,
-        type: 'deadline',
+        return {
+          id,
+          title: `Vencimiento: ${deadline.name}`,
+          message: `${companyLabel}${deadline.description || 'Revisa y gestiona este compromiso a tiempo.'}`,
+          isoDate: deadline.due_date,
+          type: 'deadline' as const,
+          companyId,
+          companyName,
+          isRead: readIds.includes(id),
+        };
+      }
+    );
+
+    const balanceNotifications = balanceSources.map(
+      ({ companyId, companyName, balance }) => ({
+        id: `balance-${companyId}-${balance.id}`,
+        title: `Balance cargado: ${balance.file_name}`,
+        message: `${
+          companyName ? `Empresa: ${companyName}. ` : ''
+        }Se registró un balance para ${
+          balance.month ? `${balance.month}/${balance.year}` : balance.year
+        }.`,
+        isoDate: balance.uploaded_at,
+        type: 'balance' as const,
         companyId,
         companyName,
-        isRead: readIds.includes(id),
-      };
-    });
-  }, [readIds, sources]);
+        isRead: readIds.includes(`balance-${companyId}-${balance.id}`),
+      })
+    );
+
+    const reportNotifications = reportEvents.map((event) => ({
+      id: event.id,
+      title: event.title,
+      message: event.message,
+      isoDate: event.isoDate,
+      type: 'report' as const,
+      companyId: event.companyId ?? 0,
+      companyName: event.companyName,
+      isRead: readIds.includes(event.id),
+    }));
+
+    return [
+      ...deadlineNotifications,
+      ...balanceNotifications,
+      ...reportNotifications,
+    ].sort(compareByIsoDateDesc);
+  }, [balanceSources, deadlineSources, readIds, reportEvents]);
 
   const unreadCount = useMemo(
     () => notifications.filter((notification) => !notification.isRead).length,

--- a/frontend/src/pages/NotificationsPage.tsx
+++ b/frontend/src/pages/NotificationsPage.tsx
@@ -1,13 +1,19 @@
 import { useContext, useEffect, useMemo, useState } from 'react';
-import { BellOff, CalendarClock, CheckCircle2, BellRing } from 'lucide-react';
+import {
+  BellOff,
+  CalendarClock,
+  CheckCircle2,
+  BellRing,
+  FileSpreadsheet,
+  Sparkles,
+} from 'lucide-react';
 import { AuthContext } from '../context/AuthContext';
 import { useCompany } from '../context/CompanyContext';
 import { useNotifications } from '../hooks/useNotifications';
 import { getCompanies } from '../services/companyService';
 import type { Company } from '../services/companyService';
 import NotificationsPageSkeleton from '../features/notifications/components/NotificationsPageSkeleton';
-
-const NOTIFICATIONS_ALLOWED_ROLES = ['admin', 'contador_family_office'];
+import { NOTIFICATIONS_ALLOWED_ROLES } from '../constants/authorization';
 
 const formatNotificationDate = (isoDate: string) => {
   const [year, month, day] = isoDate
@@ -27,7 +33,23 @@ const formatNotificationDate = (isoDate: string) => {
   }).format(parsedDate);
 };
 
-const getNotificationVisual = () => {
+const getNotificationVisual = (type: 'deadline' | 'balance' | 'report') => {
+  if (type === 'balance') {
+    return {
+      icon: FileSpreadsheet,
+      label: 'Balance',
+      tone: 'text-primary',
+    };
+  }
+
+  if (type === 'report') {
+    return {
+      icon: Sparkles,
+      label: 'Reporte',
+      tone: 'text-secondary',
+    };
+  }
+
   return {
     icon: CalendarClock,
     label: 'Vencimiento',
@@ -49,7 +71,10 @@ export default function NotificationsPage() {
   const hasNotificationsAccess =
     !!user?.role && NOTIFICATIONS_ALLOWED_ROLES.includes(user.role);
   const hasEnabledAlerts =
-    hasNotificationsAccess && !!user?.alert_deadlines_enabled;
+    hasNotificationsAccess &&
+    (!!user?.alert_deadlines_enabled ||
+      !!user?.alert_balances_enabled ||
+      !!user?.alert_reports_enabled);
 
   useEffect(() => {
     if (!hasEnabledAlerts) {
@@ -330,12 +355,12 @@ export default function NotificationsPage() {
                   </div>
                 ) : (
                   visibleNotifications.map((notification) => {
-                    const visual = getNotificationVisual();
+                    const visual = getNotificationVisual(notification.type);
                     const Icon = visual.icon;
-                    const titleWithoutPrefix = notification.title.replace(
-                      /^Vencimiento:\s*/,
-                      ''
-                    );
+                    const titleWithoutPrefix =
+                      notification.type === 'deadline'
+                        ? notification.title.replace(/^Vencimiento:\s*/, '')
+                        : notification.title;
 
                     return (
                       <article

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -17,6 +17,8 @@ type AlertKey =
   | 'alert_balances_enabled'
   | 'alert_reports_enabled';
 
+type AlertPreferences = Record<AlertKey, boolean>;
+
 const alertOptions: Array<{
   key: AlertKey;
   title: string;
@@ -46,10 +48,15 @@ const alertOptions: Array<{
 ];
 
 export default function SettingsPage() {
-  const { user, patchUser, setUser, refreshUser } = useContext(AuthContext);
+  const { user, setUser, refreshUser } = useContext(AuthContext);
   const isAdmin = user?.role === 'admin';
   const [fullName, setFullName] = useState('');
   const [email, setEmail] = useState('');
+  const [alertPreferences, setAlertPreferences] = useState<AlertPreferences>({
+    alert_deadlines_enabled: false,
+    alert_balances_enabled: false,
+    alert_reports_enabled: false,
+  });
   const [reminderStartDays, setReminderStartDays] = useState(5);
   const [reminderEndDays, setReminderEndDays] = useState(7);
   const [saving, setSaving] = useState(false);
@@ -60,6 +67,11 @@ export default function SettingsPage() {
     if (!user) return;
     setFullName(user.full_name ?? '');
     setEmail(user.email);
+    setAlertPreferences({
+      alert_deadlines_enabled: user.alert_deadlines_enabled,
+      alert_balances_enabled: user.alert_balances_enabled,
+      alert_reports_enabled: user.alert_reports_enabled,
+    });
     setReminderStartDays(user.reminder_window_start_days);
     setReminderEndDays(user.reminder_window_end_days);
   }, [user]);
@@ -67,7 +79,10 @@ export default function SettingsPage() {
   if (!user) return null;
 
   const handleToggleAlert = (key: AlertKey) => {
-    patchUser({ [key]: !user[key] });
+    setAlertPreferences((currentPreferences) => ({
+      ...currentPreferences,
+      [key]: !currentPreferences[key],
+    }));
     setMessage(null);
     setError(null);
   };
@@ -93,9 +108,9 @@ export default function SettingsPage() {
       const updatedUser = await updateMe({
         full_name: fullName.trim(),
         email: email.trim(),
-        alert_deadlines_enabled: user.alert_deadlines_enabled,
-        alert_balances_enabled: user.alert_balances_enabled,
-        alert_reports_enabled: user.alert_reports_enabled,
+        alert_deadlines_enabled: alertPreferences.alert_deadlines_enabled,
+        alert_balances_enabled: alertPreferences.alert_balances_enabled,
+        alert_reports_enabled: alertPreferences.alert_reports_enabled,
         reminder_window_start_days: isAdmin
           ? reminderStartDays
           : user.reminder_window_start_days,
@@ -229,14 +244,20 @@ export default function SettingsPage() {
                     <button
                       type="button"
                       onClick={() => handleToggleAlert(key)}
-                      aria-label={`Alternar ${title}`}
-                      className={`relative inline-flex h-7 w-12 items-center rounded-full transition-colors duration-200 ${
-                        user[key] ? 'bg-secondary' : 'bg-neutral-border'
+                      role="switch"
+                      aria-label={title}
+                      aria-checked={alertPreferences[key]}
+                      className={`relative mt-1 inline-flex h-8 w-14 flex-shrink-0 items-center rounded-full border border-transparent transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-secondary/30 ${
+                        alertPreferences[key]
+                          ? 'bg-secondary shadow-sm shadow-secondary/20'
+                          : 'bg-neutral-border'
                       }`}
                     >
                       <span
-                        className={`inline-block h-5 w-5 transform rounded-full bg-white transition-transform duration-200 ${
-                          user[key] ? 'translate-x-6' : 'translate-x-1'
+                        className={`inline-block h-6 w-6 transform rounded-full bg-white shadow-sm transition-transform duration-200 ${
+                          alertPreferences[key]
+                            ? 'translate-x-7'
+                            : 'translate-x-1'
                         }`}
                       />
                     </button>

--- a/frontend/src/services/notificationEventService.ts
+++ b/frontend/src/services/notificationEventService.ts
@@ -1,0 +1,51 @@
+export type StoredNotificationEventType = 'report';
+
+export interface StoredNotificationEvent {
+  id: string;
+  type: StoredNotificationEventType;
+  title: string;
+  message: string;
+  isoDate: string;
+  companyId?: number;
+  companyName?: string;
+}
+
+const buildStorageKey = (userId: number) =>
+  `conexia.notifications.events.${userId}`;
+
+const parseStoredEvents = (rawValue: string | null): StoredNotificationEvent[] => {
+  if (!rawValue) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(rawValue);
+    return Array.isArray(parsed)
+      ? parsed.filter(
+          (value): value is StoredNotificationEvent =>
+            typeof value?.id === 'string' &&
+            typeof value?.type === 'string' &&
+            typeof value?.title === 'string' &&
+            typeof value?.message === 'string' &&
+            typeof value?.isoDate === 'string'
+        )
+      : [];
+  } catch {
+    return [];
+  }
+};
+
+export const getStoredNotificationEvents = (
+  userId: number
+): StoredNotificationEvent[] => {
+  return parseStoredEvents(localStorage.getItem(buildStorageKey(userId)));
+};
+
+export const appendStoredNotificationEvent = (
+  userId: number,
+  event: StoredNotificationEvent
+) => {
+  const currentEvents = getStoredNotificationEvents(userId);
+  const nextEvents = [event, ...currentEvents.filter((item) => item.id !== event.id)];
+  localStorage.setItem(buildStorageKey(userId), JSON.stringify(nextEvents.slice(0, 50)));
+};

--- a/frontend/src/services/notificationEventService.ts
+++ b/frontend/src/services/notificationEventService.ts
@@ -13,7 +13,9 @@ export interface StoredNotificationEvent {
 const buildStorageKey = (userId: number) =>
   `conexia.notifications.events.${userId}`;
 
-const parseStoredEvents = (rawValue: string | null): StoredNotificationEvent[] => {
+const parseStoredEvents = (
+  rawValue: string | null
+): StoredNotificationEvent[] => {
   if (!rawValue) {
     return [];
   }
@@ -46,6 +48,12 @@ export const appendStoredNotificationEvent = (
   event: StoredNotificationEvent
 ) => {
   const currentEvents = getStoredNotificationEvents(userId);
-  const nextEvents = [event, ...currentEvents.filter((item) => item.id !== event.id)];
-  localStorage.setItem(buildStorageKey(userId), JSON.stringify(nextEvents.slice(0, 50)));
+  const nextEvents = [
+    event,
+    ...currentEvents.filter((item) => item.id !== event.id),
+  ];
+  localStorage.setItem(
+    buildStorageKey(userId),
+    JSON.stringify(nextEvents.slice(0, 50))
+  );
 };


### PR DESCRIPTION
## Objetivo

Implementar la HU-011 para restringir el acceso al módulo de Flujo de Caja exclusivamente al perfil Administrador, reforzando el control por roles en backend y frontend para proteger la información financiera sensible.

## Cambios Principales

- Se restringió el acceso al módulo `cash-flow` en backend para que solo el rol `admin`  y `contador_cole_co` pueda consumir sus endpoints.
- Se ocultó la opción `Flujo de Caja` del menú lateral para usuarios no administradores.
- Se protegió la ruta `/flujo-de-caja` en frontend para evitar acceso por URL directa a usuarios no autorizados, redirigiéndolos a `/dashboard`.
- Se centralizaron constantes de autorización para evitar lógica duplicada de roles.
- Se añadieron pruebas para validar restricciones de acceso tanto en backend como en frontend.

## Como probarlo

1. Iniciar sesión con un usuario que no sea `admin`.
2. Verificar que no aparezca la opción `Flujo de Caja` en el sidebar.
3. Intentar entrar manualmente a `/flujo-de-caja` y confirmar que redirige a `/dashboard`.
4. Confirmar que los endpoints de `cash-flow` rechazan acceso para roles no autorizados.
5. Iniciar sesión con un usuario `admin`.
6. Verificar que el módulo `Flujo de Caja` sí aparezca en el menú y que la ruta funcione correctamente.
7. Ejecutar las pruebas:
   - `python -m unittest tests.test_cash_flow_router tests.test_auth_router`
   - `npm.cmd test -- --run Sidebar.test.tsx ProtectedRoute.test.tsx`

## Notas Adicionales

- La solución sigue el enfoque de defensa en profundidad: ocultamiento en UI más validación obligatoria en backend.
- El cambio se enfocó en restringir la visibilidad y el acceso efectivo al módulo de Flujo de Caja según el rol del usuario.
