### PR TITLE
feat: dashboard COLE&CO

### DIFF
--- a/frontend/src/features/cash-flow/components/MonthlyClosingPanel.tsx
+++ b/frontend/src/features/cash-flow/components/MonthlyClosingPanel.tsx
@@ -97,7 +97,7 @@ export default function MonthlyClosingPanel({
               htmlFor="closing-year"
               className="block text-xs font-semibold text-neutral-muted mb-1"
             >
-              Ano
+              Año
             </label>
             <input
               id="closing-year"

--- a/frontend/src/features/cash-flow/dashboard/components/CashFlowAccountsGrid.tsx
+++ b/frontend/src/features/cash-flow/dashboard/components/CashFlowAccountsGrid.tsx
@@ -1,0 +1,113 @@
+import type { FC } from 'react';
+import type { CuentaResumen } from '../types';
+
+interface CashFlowAccountsGridProps {
+  cuentas: CuentaResumen[];
+  loading: boolean;
+  onVerCuenta?: (cuentaId: string) => void;
+}
+
+const formatCOP = (value: number): string =>
+  new Intl.NumberFormat('es-CO', {
+    style: 'currency',
+    currency: 'COP',
+    maximumFractionDigits: 0,
+  }).format(value);
+
+const COLORES_BORDE = [
+  'border-l-blue-400',
+  'border-l-emerald-400',
+  'border-l-amber-400',
+  'border-l-violet-400',
+  'border-l-cyan-400',
+  'border-l-rose-400',
+];
+
+const CuentaCardSkeleton: FC = () => (
+  <div className="animate-pulse bg-neutral-surface rounded-xl border border-neutral-border p-4 space-y-3">
+    <div className="h-3 w-1/2 bg-neutral-border rounded" />
+    <div className="h-6 w-3/4 bg-neutral-border rounded" />
+    <div className="flex gap-4">
+      <div className="h-2.5 bg-neutral-border rounded w-1/3" />
+      <div className="h-2.5 bg-neutral-border rounded w-1/3" />
+    </div>
+  </div>
+);
+
+const CashFlowAccountsGrid: FC<CashFlowAccountsGridProps> = ({
+  cuentas,
+  loading,
+  onVerCuenta,
+}) => {
+  return (
+    <div className="bg-neutral-surface rounded-2xl border border-neutral-border p-5 shadow-sm">
+      <div className="flex items-center justify-between mb-4">
+        <div>
+          <h3 className="text-sm font-semibold text-neutral-800">
+            Saldos por cuenta
+          </h3>
+          <p className="text-xs text-neutral-400 mt-0.5">
+            Estado actual de cada cuenta activa
+          </p>
+        </div>
+        {!loading && (
+          <span className="text-xs bg-blue-50 text-blue-600 font-semibold px-2.5 py-1 rounded-full">
+            {cuentas.length} activas
+          </span>
+        )}
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        {loading
+          ? Array.from({ length: 4 }).map((_, i) => (
+              <CuentaCardSkeleton key={i} />
+            ))
+          : cuentas.map((cuenta, index) => {
+              const bordeColor = COLORES_BORDE[index % COLORES_BORDE.length];
+              const tieneCierrePendiente = cuenta.cierresPendientes > 0;
+
+              return (
+                <button
+                  key={cuenta.id}
+                  onClick={() => onVerCuenta?.(cuenta.id)}
+                  className={`text-left bg-neutral-50 hover:bg-neutral-100 transition-colors rounded-xl border border-l-4 border-neutral-200 ${bordeColor} p-4 group`}
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0">
+                      <p className="text-xs font-semibold text-neutral-700 truncate">
+                        {cuenta.nombre}
+                      </p>
+                      {cuenta.descripcion && (
+                        <p className="text-xs text-neutral-400 truncate mt-0.5">
+                          {cuenta.descripcion}
+                        </p>
+                      )}
+                    </div>
+                    {tieneCierrePendiente && (
+                      <span className="shrink-0 text-xs bg-amber-100 text-amber-700 font-medium px-2 py-0.5 rounded-full">
+                        Cierre pendiente
+                      </span>
+                    )}
+                  </div>
+
+                  <p className="text-lg font-bold text-neutral-900 mt-3">
+                    {formatCOP(cuenta.saldo)}
+                  </p>
+
+                  <div className="flex items-center gap-3 mt-2">
+                    <span className="text-xs text-emerald-600 font-medium">
+                      ↑ {formatCOP(cuenta.ingresos)}
+                    </span>
+                    <span className="text-xs text-red-500 font-medium">
+                      ↓ {formatCOP(cuenta.egresos)}
+                    </span>
+                  </div>
+                </button>
+              );
+            })}
+      </div>
+    </div>
+  );
+};
+
+export default CashFlowAccountsGrid;

--- a/frontend/src/features/cash-flow/dashboard/components/CashFlowActivityPanel.tsx
+++ b/frontend/src/features/cash-flow/dashboard/components/CashFlowActivityPanel.tsx
@@ -1,0 +1,271 @@
+import type { FC } from 'react';
+import type { CierreResumen, MovimientoResumen } from '../types';
+
+interface CashFlowActivityPanelProps {
+  movimientosRecientes: MovimientoResumen[];
+  ultimosCierres: CierreResumen[];
+  loading: boolean;
+  onVerTodos: () => void;
+  onIrACierres: () => void;
+}
+
+const formatCOP = (value: number): string =>
+  new Intl.NumberFormat('es-CO', {
+    style: 'currency',
+    currency: 'COP',
+    maximumFractionDigits: 0,
+  }).format(value);
+
+const formatFecha = (fechaStr: string): string => {
+  const fecha = new Date(fechaStr);
+  return fecha.toLocaleDateString('es-CO', {
+    day: '2-digit',
+    month: 'short',
+  });
+};
+
+const RowSkeleton: FC = () => (
+  <div className="animate-pulse flex items-center gap-3 py-3">
+    <div className="w-8 h-8 rounded-full bg-neutral-border shrink-0" />
+    <div className="flex-1 space-y-1.5">
+      <div className="h-3.5 bg-neutral-border rounded w-2/3" />
+      <div className="h-3 bg-neutral-border rounded w-1/3" />
+    </div>
+    <div className="h-4 bg-neutral-border rounded w-20" />
+  </div>
+);
+
+const CashFlowActivityPanel: FC<CashFlowActivityPanelProps> = ({
+  movimientosRecientes,
+  ultimosCierres,
+  loading,
+  onVerTodos,
+  onIrACierres,
+}) => {
+  return (
+    <div className="grid grid-cols-1 xl:grid-cols-2 gap-4 mb-6">
+      {/* Movimientos recientes */}
+      <div className="bg-neutral-surface rounded-2xl border border-neutral-border p-5 shadow-sm">
+        {loading ? (
+          <div className="animate-pulse">
+            <div className="flex items-center justify-between mb-6">
+              <div className="h-4 w-44 bg-neutral-border rounded" />
+              <div className="h-3 w-16 bg-neutral-border rounded" />
+            </div>
+            {Array.from({ length: 4 }).map((_, i) => (
+              <RowSkeleton key={i} />
+            ))}
+          </div>
+        ) : (
+          <>
+            <div className="flex items-center justify-between mb-4">
+              <div>
+                <h3 className="text-sm font-semibold text-neutral-800">
+                  Movimientos recientes
+                </h3>
+                <p className="text-xs text-neutral-400 mt-0.5">
+                  Últimas transacciones registradas
+                </p>
+              </div>
+              <button
+                onClick={onVerTodos}
+                className="text-xs text-blue-600 font-medium hover:text-blue-800 transition-colors"
+              >
+                Ver todos
+              </button>
+            </div>
+            <div className="divide-y divide-neutral-100">
+              {movimientosRecientes.length === 0 ? (
+                <p className="text-xs text-neutral-400 text-center py-8">
+                  No hay movimientos registrados.
+                </p>
+              ) : (
+                movimientosRecientes.map((mov) => {
+                  const esIngreso = mov.tipo === 'ingreso';
+                  return (
+                    <div key={mov.id} className="flex items-center gap-3 py-3">
+                      <span
+                        className={`w-8 h-8 rounded-full flex items-center justify-center shrink-0 ${
+                          esIngreso
+                            ? 'bg-emerald-50 text-emerald-600'
+                            : 'bg-red-50 text-red-500'
+                        }`}
+                      >
+                        {esIngreso ? (
+                          <svg
+                            className="w-4 h-4"
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={2}
+                              d="M7 11l5-5m0 0l5 5m-5-5v12"
+                            />
+                          </svg>
+                        ) : (
+                          <svg
+                            className="w-4 h-4"
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={2}
+                              d="M17 13l-5 5m0 0l-5-5m5 5V6"
+                            />
+                          </svg>
+                        )}
+                      </span>
+
+                      <div className="flex-1 min-w-0">
+                        <p className="text-xs font-semibold text-neutral-800 truncate">
+                          {mov.concepto}
+                        </p>
+                        <p className="text-xs text-neutral-400 truncate">
+                          {mov.cuenta} · {formatFecha(mov.fecha)}
+                        </p>
+                      </div>
+
+                      <span
+                        className={`text-xs font-bold shrink-0 ${
+                          esIngreso ? 'text-emerald-600' : 'text-red-500'
+                        }`}
+                      >
+                        {esIngreso ? '+' : '-'}
+                        {formatCOP(mov.monto)}
+                      </span>
+                    </div>
+                  );
+                })
+              )}
+            </div>
+          </>
+        )}
+      </div>
+
+      {/* Estado de cierres mensuales */}
+      <div className="bg-neutral-surface rounded-2xl border border-neutral-border p-5 shadow-sm">
+        {loading ? (
+          <div className="animate-pulse">
+            <div className="flex items-center justify-between mb-6">
+              <div className="h-4 w-44 bg-neutral-border rounded" />
+              <div className="h-3 w-16 bg-neutral-border rounded" />
+            </div>
+            {Array.from({ length: 3 }).map((_, i) => (
+              <RowSkeleton key={i} />
+            ))}
+          </div>
+        ) : (
+          <>
+            <div className="flex items-center justify-between mb-4">
+              <div>
+                <h3 className="text-sm font-semibold text-neutral-800">
+                  Estado de cierres
+                </h3>
+                <p className="text-xs text-neutral-400 mt-0.5">
+                  Último cierre mensual por cuenta
+                </p>
+              </div>
+              <button
+                onClick={onIrACierres}
+                className="text-xs text-blue-600 font-medium hover:text-blue-800 transition-colors"
+              >
+                Ir a cierres
+              </button>
+            </div>
+            <div className="divide-y divide-neutral-100">
+              {ultimosCierres.length === 0 ? (
+                <p className="text-xs text-neutral-400 text-center py-8">
+                  Sin cierres registrados.
+                </p>
+              ) : (
+                ultimosCierres.map((cierre) => {
+                  const esCerrado = cierre.estado === 'cerrado';
+                  const balancePositivo = cierre.ingresos - cierre.egresos >= 0;
+
+                  return (
+                    <div
+                      key={cierre.id}
+                      className="flex items-center gap-3 py-3"
+                    >
+                      <span
+                        className={`w-8 h-8 rounded-full flex items-center justify-center shrink-0 ${
+                          esCerrado
+                            ? 'bg-emerald-50 text-emerald-600'
+                            : 'bg-amber-50 text-amber-600'
+                        }`}
+                      >
+                        {esCerrado ? (
+                          <svg
+                            className="w-4 h-4"
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={2}
+                              d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
+                            />
+                          </svg>
+                        ) : (
+                          <svg
+                            className="w-4 h-4"
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={2}
+                              d="M8 11V7a4 4 0 118 0m-4 8v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2z"
+                            />
+                          </svg>
+                        )}
+                      </span>
+
+                      <div className="flex-1 min-w-0">
+                        <p className="text-xs font-semibold text-neutral-800 truncate">
+                          {cierre.cuenta}
+                        </p>
+                        <p className="text-xs text-neutral-400">
+                          {cierre.periodo}
+                        </p>
+                      </div>
+
+                      <div className="text-right shrink-0">
+                        <p
+                          className={`text-xs font-bold ${balancePositivo ? 'text-emerald-600' : 'text-red-500'}`}
+                        >
+                          {formatCOP(cierre.saldoCierre)}
+                        </p>
+                        <span
+                          className={`text-xs font-medium px-2 py-0.5 rounded-full ${
+                            esCerrado
+                              ? 'bg-emerald-50 text-emerald-700'
+                              : 'bg-amber-50 text-amber-700'
+                          }`}
+                        >
+                          {esCerrado ? 'Cerrado' : 'Abierto'}
+                        </span>
+                      </div>
+                    </div>
+                  );
+                })
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default CashFlowActivityPanel;

--- a/frontend/src/features/cash-flow/dashboard/components/CashFlowChartsRow.tsx
+++ b/frontend/src/features/cash-flow/dashboard/components/CashFlowChartsRow.tsx
@@ -1,0 +1,260 @@
+import type { FC } from 'react';
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  PieChart,
+  Pie,
+  Cell,
+  Legend,
+} from 'recharts';
+import type { CashFlowDashboardMetrics } from '../types';
+
+interface CashFlowChartsRowProps {
+  metrics: CashFlowDashboardMetrics;
+  loading: boolean;
+}
+
+interface TooltipPayloadEntry {
+  dataKey: string;
+  name: string;
+  value: number;
+  color: string;
+}
+
+interface TooltipProps {
+  active?: boolean;
+  payload?: TooltipPayloadEntry[];
+  label?: string;
+}
+
+const COLORES_CUENTA = [
+  '#3b82f6',
+  '#10b981',
+  '#f59e0b',
+  '#8b5cf6',
+  '#ef4444',
+  '#06b6d4',
+];
+
+const formatMillones = (value: number) => {
+  if (value >= 1_000_000) return `$${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `$${(value / 1_000).toFixed(0)}K`;
+  return `$${value}`;
+};
+
+const formatCOP = (value: number): string =>
+  new Intl.NumberFormat('es-CO', {
+    style: 'currency',
+    currency: 'COP',
+    maximumFractionDigits: 0,
+  }).format(value);
+
+const TooltipFlujo: FC<TooltipProps> = ({ active, payload, label }) => {
+  if (!active || !payload?.length) return null;
+  return (
+    <div className="bg-white border border-neutral-200 rounded-xl shadow-lg p-3 text-xs">
+      <p className="font-semibold text-neutral-700 mb-2">{label}</p>
+      {payload.map((entry) => (
+        <p
+          key={entry.dataKey}
+          style={{ color: entry.color }}
+          className="flex gap-2 justify-between"
+        >
+          <span>{entry.name}</span>
+          <span className="font-medium">{formatMillones(entry.value)}</span>
+        </p>
+      ))}
+    </div>
+  );
+};
+
+const TooltipDonut: FC<TooltipProps> = ({ active, payload }) => {
+  if (!active || !payload?.length) return null;
+  const { name, value } = payload[0];
+  return (
+    <div className="bg-white border border-neutral-200 rounded-xl shadow-lg p-3 text-xs">
+      <p className="font-semibold text-neutral-700">{name}</p>
+      <p className="text-neutral-500 mt-1">{formatCOP(value)}</p>
+    </div>
+  );
+};
+
+const CashFlowChartsRow: FC<CashFlowChartsRowProps> = ({
+  metrics,
+  loading,
+}) => {
+  const datosFlujo =
+    metrics.puntosFlujo.length > 0
+      ? metrics.puntosFlujo
+      : [{ fecha: '—', ingresos: 0, egresos: 0, saldo: 0 }];
+
+  const datosDonut = metrics.cuentas.map((c, i) => ({
+    name: c.nombre,
+    value: c.saldo,
+    color: COLORES_CUENTA[i % COLORES_CUENTA.length],
+  }));
+
+  const chartSkeleton = (
+    <div className="animate-pulse">
+      <div className="flex items-center justify-between mb-6">
+        <div className="h-4 w-44 bg-neutral-border rounded" />
+        <div className="h-3 w-16 bg-neutral-border rounded" />
+      </div>
+      <div className="h-52 bg-neutral-border rounded-xl" />
+    </div>
+  );
+
+  return (
+    <div className="grid grid-cols-1 xl:grid-cols-2 gap-4 mb-6">
+      {/* Gráfico de área */}
+      <div className="bg-neutral-surface rounded-2xl border border-neutral-border p-6 shadow-sm">
+        {loading ? (
+          chartSkeleton
+        ) : (
+          <>
+            <div className="flex items-center justify-between mb-4">
+              <div>
+                <h3 className="text-sm font-semibold text-neutral-800">
+                  Flujo de caja
+                </h3>
+                <p className="text-xs text-neutral-400 mt-0.5">
+                  Ingresos y egresos en el tiempo
+                </p>
+              </div>
+              <span className="text-xs text-neutral-400 font-medium">
+                {metrics.totalMovimientos} movimientos
+              </span>
+            </div>
+            <ResponsiveContainer width="100%" height={220}>
+              <AreaChart
+                data={datosFlujo}
+                margin={{ top: 4, right: 4, left: 0, bottom: 0 }}
+              >
+                <defs>
+                  <linearGradient id="gradIngreso" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="5%" stopColor="#10b981" stopOpacity={0.15} />
+                    <stop offset="95%" stopColor="#10b981" stopOpacity={0} />
+                  </linearGradient>
+                  <linearGradient id="gradEgreso" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="5%" stopColor="#ef4444" stopOpacity={0.15} />
+                    <stop offset="95%" stopColor="#ef4444" stopOpacity={0} />
+                  </linearGradient>
+                </defs>
+                <CartesianGrid strokeDasharray="3 3" stroke="#f3f4f6" />
+                <XAxis
+                  dataKey="fecha"
+                  tick={{ fontSize: 11, fill: '#9ca3af' }}
+                  axisLine={false}
+                  tickLine={false}
+                />
+                <YAxis
+                  tickFormatter={formatMillones}
+                  tick={{ fontSize: 11, fill: '#9ca3af' }}
+                  axisLine={false}
+                  tickLine={false}
+                  width={50}
+                />
+                <Tooltip content={<TooltipFlujo />} />
+                <Area
+                  type="monotone"
+                  dataKey="ingresos"
+                  name="Ingresos"
+                  stroke="#10b981"
+                  strokeWidth={2}
+                  fill="url(#gradIngreso)"
+                  dot={false}
+                  activeDot={{ r: 4 }}
+                />
+                <Area
+                  type="monotone"
+                  dataKey="egresos"
+                  name="Egresos"
+                  stroke="#ef4444"
+                  strokeWidth={2}
+                  fill="url(#gradEgreso)"
+                  dot={false}
+                  activeDot={{ r: 4 }}
+                />
+              </AreaChart>
+            </ResponsiveContainer>
+            <div className="flex gap-4 mt-3">
+              <span className="flex items-center gap-1.5 text-xs text-neutral-500">
+                <span className="w-2.5 h-2.5 rounded-full bg-emerald-500 inline-block" />
+                Ingresos
+              </span>
+              <span className="flex items-center gap-1.5 text-xs text-neutral-500">
+                <span className="w-2.5 h-2.5 rounded-full bg-red-500 inline-block" />
+                Egresos
+              </span>
+            </div>
+          </>
+        )}
+      </div>
+
+      {/* Donut */}
+      <div className="bg-neutral-surface rounded-2xl border border-neutral-border p-6 shadow-sm">
+        {loading ? (
+          chartSkeleton
+        ) : (
+          <>
+            <div className="flex items-center justify-between mb-4">
+              <div>
+                <h3 className="text-sm font-semibold text-neutral-800">
+                  Distribución por cuenta
+                </h3>
+                <p className="text-xs text-neutral-400 mt-0.5">
+                  Peso relativo del saldo disponible
+                </p>
+              </div>
+              <span className="text-xs text-neutral-400 font-medium">
+                {metrics.cuentasActivas} cuentas
+              </span>
+            </div>
+            <ResponsiveContainer width="100%" height={220}>
+              <PieChart margin={{ top: 0, right: 0, bottom: 0, left: 0 }}>
+                <Pie
+                  data={datosDonut}
+                  cx="50%"
+                  cy="45%"
+                  innerRadius={60}
+                  outerRadius={88}
+                  paddingAngle={3}
+                  dataKey="value"
+                >
+                  {datosDonut.map((entry, index) => (
+                    <Cell key={`cell-${index}`} fill={entry.color} />
+                  ))}
+                </Pie>
+                <Tooltip content={<TooltipDonut />} />
+                <Legend
+                  iconType="circle"
+                  iconSize={8}
+                  layout="horizontal"
+                  verticalAlign="bottom"
+                  align="center"
+                  wrapperStyle={{
+                    paddingTop: '8px',
+                    fontSize: '11px',
+                    lineHeight: '20px',
+                  }}
+                  formatter={(value) => (
+                    <span style={{ color: '#6b7280', fontSize: '11px' }}>
+                      {value}
+                    </span>
+                  )}
+                />
+              </PieChart>
+            </ResponsiveContainer>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default CashFlowChartsRow;

--- a/frontend/src/features/cash-flow/dashboard/components/CashFlowDashboard.tsx
+++ b/frontend/src/features/cash-flow/dashboard/components/CashFlowDashboard.tsx
@@ -1,0 +1,75 @@
+import type { FC } from 'react';
+import { useCashFlowData } from '../hooks/useCashFlowData';
+import { useCashFlowDashboard } from '../hooks/useCashFlowDashboard';
+import CashFlowDashboardHeader from './CashFlowDashboardHeader';
+import CashFlowMetricsGrid from './CashFlowMetricsGrid';
+import CashFlowChartsRow from './CashFlowChartsRow';
+import CashFlowAccountsGrid from './CashFlowAccountsGrid';
+import CashFlowActivityPanel from './CashFlowActivityPanel';
+
+interface CashFlowDashboardProps {
+  currentDateText: string;
+  fullName?: string;
+  onIrAMovimientos: () => void;
+  onIrACierres: () => void;
+  onVerCuenta?: (cuentaId: string) => void;
+}
+
+/**
+ * CashFlowDashboard
+ *
+ * Dashboard principal del módulo Flujo de Caja. Orquesta el fetch de datos,
+ * el cálculo de métricas y la renderización de todos los sub-componentes.
+ *
+ * Estructura de la página:
+ * 1. Header con saludo y acceso rápido a "Registrar movimiento"
+ * 2. Tarjetas de métricas clave (saldo, ingresos, egresos, balance)
+ * 3. Fila de gráficos (flujo de caja en el tiempo + distribución por cuenta)
+ * 4. Saldos por cuenta (grid de tarjetas individuales)
+ * 5. Panel de actividad: movimientos recientes + estado de cierres
+ */
+const CashFlowDashboard: FC<CashFlowDashboardProps> = ({
+  currentDateText,
+  fullName,
+  onIrAMovimientos,
+  onIrACierres,
+  onVerCuenta,
+}) => {
+  // TODO: Conectar periodo con un selector de período cuando sea necesario
+  const periodo = 'mes_actual';
+
+  const { cuentas, movimientos, cierres, loading } = useCashFlowData(periodo);
+  const metrics = useCashFlowDashboard(cuentas, movimientos, cierres);
+
+  return (
+    <>
+      <CashFlowDashboardHeader
+        currentDateText={currentDateText}
+        fullName={fullName}
+        onIrAMovimientos={onIrAMovimientos}
+      />
+
+      <CashFlowMetricsGrid metrics={metrics} loading={loading} />
+
+      <CashFlowChartsRow metrics={metrics} loading={loading} />
+
+      <div className="grid grid-cols-1 xl:grid-cols-2 gap-4 mb-6">
+        <CashFlowAccountsGrid
+          cuentas={metrics.cuentas}
+          loading={loading}
+          onVerCuenta={onVerCuenta}
+        />
+
+        <CashFlowActivityPanel
+          movimientosRecientes={metrics.movimientosRecientes}
+          ultimosCierres={metrics.ultimosCierres}
+          loading={loading}
+          onVerTodos={onIrAMovimientos}
+          onIrACierres={onIrACierres}
+        />
+      </div>
+    </>
+  );
+};
+
+export default CashFlowDashboard;

--- a/frontend/src/features/cash-flow/dashboard/components/CashFlowDashboardHeader.tsx
+++ b/frontend/src/features/cash-flow/dashboard/components/CashFlowDashboardHeader.tsx
@@ -1,0 +1,48 @@
+import type { FC } from 'react';
+
+interface CashFlowDashboardHeaderProps {
+  currentDateText: string;
+  fullName?: string;
+  onIrAMovimientos: () => void;
+}
+
+const CashFlowDashboardHeader: FC<CashFlowDashboardHeaderProps> = ({
+  currentDateText,
+  onIrAMovimientos,
+}) => {
+  return (
+    <div className="flex items-start justify-between mb-6">
+      <div>
+        <h1 className="text-2xl font-bold text-primary font-hubot tracking-tight">
+          Dashboard COLE&CO
+        </h1>
+        <p className="text-sm text-neutral-500 mt-1">
+          Resumen de cuentas, movimientos y cierres del flujo de caja ·{' '}
+          {currentDateText}
+        </p>
+      </div>
+
+      <button
+        onClick={onIrAMovimientos}
+        className="flex items-center gap-2 bg-neutral-900 text-white text-sm font-medium px-4 py-2 rounded-lg hover:bg-neutral-700 transition-colors"
+      >
+        <svg
+          className="w-4 h-4"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M12 4v16m8-8H4"
+          />
+        </svg>
+        Registrar movimiento
+      </button>
+    </div>
+  );
+};
+
+export default CashFlowDashboardHeader;

--- a/frontend/src/features/cash-flow/dashboard/components/CashFlowMetricsGrid.tsx
+++ b/frontend/src/features/cash-flow/dashboard/components/CashFlowMetricsGrid.tsx
@@ -1,0 +1,195 @@
+import type { FC } from 'react';
+import type { CashFlowDashboardMetrics } from '../types';
+
+interface CashFlowMetricsGridProps {
+  metrics: CashFlowDashboardMetrics;
+  loading: boolean;
+}
+
+const formatCOP = (value: number): string => {
+  return new Intl.NumberFormat('es-CO', {
+    style: 'currency',
+    currency: 'COP',
+    maximumFractionDigits: 0,
+  }).format(value);
+};
+
+interface StatCardProps {
+  titulo: string;
+  valor: string | number;
+  descripcion: string;
+  variante?: 'default' | 'positivo' | 'negativo' | 'neutro';
+  icono: React.ReactNode;
+  loading: boolean;
+}
+
+const StatCard: FC<StatCardProps> = ({
+  titulo,
+  valor,
+  descripcion,
+  variante = 'default',
+  icono,
+  loading,
+}) => {
+  const borderClass = {
+    default: 'border-neutral-200',
+    positivo: 'border-emerald-200',
+    negativo: 'border-red-200',
+    neutro: 'border-blue-200',
+  }[variante];
+
+  const iconBgClass = {
+    default: 'bg-neutral-100 text-neutral-600',
+    positivo: 'bg-emerald-50 text-emerald-600',
+    negativo: 'bg-red-50 text-red-500',
+    neutro: 'bg-blue-50 text-blue-600',
+  }[variante];
+
+  if (loading) {
+    return (
+      <div className="bg-neutral-surface border border-neutral-border rounded-2xl p-5 shadow-sm animate-pulse">
+        <div className="flex items-center justify-between mb-4">
+          <div className="h-3 w-28 bg-neutral-border rounded" />
+          <div className="w-9 h-9 rounded-xl bg-neutral-border" />
+        </div>
+        <div className="h-10 w-20 bg-neutral-border rounded-lg mb-3" />
+        <div className="h-2.5 w-full bg-neutral-border rounded mb-1.5" />
+        <div className="h-2.5 w-3/4 bg-neutral-border rounded" />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`bg-neutral-surface rounded-2xl border shadow-sm ${borderClass} p-5 flex flex-col gap-3`}
+    >
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-semibold uppercase tracking-widest text-neutral-400">
+          {titulo}
+        </span>
+        <span
+          className={`w-9 h-9 rounded-xl flex items-center justify-center ${iconBgClass}`}
+        >
+          {icono}
+        </span>
+      </div>
+      <p className="text-2xl font-bold tracking-tight text-neutral-900">
+        {valor}
+      </p>
+      <p className="text-xs text-neutral-400">{descripcion}</p>
+    </div>
+  );
+};
+
+const CashFlowMetricsGrid: FC<CashFlowMetricsGridProps> = ({
+  metrics,
+  loading,
+}) => {
+  const balancePositivo = metrics.balanceNeto >= 0;
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4 mb-6">
+      {/* Saldo total — más prominente, ocupa más peso visual */}
+      <StatCard
+        titulo="Saldo total disponible"
+        valor={loading ? '—' : formatCOP(metrics.saldoTotalDisponible)}
+        descripcion={`Entre ${metrics.cuentasActivas} cuentas activas`}
+        variante="neutro"
+        loading={loading}
+        icono={
+          <svg
+            className="w-5 h-5"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={1.8}
+              d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z"
+            />
+          </svg>
+        }
+      />
+
+      {/* Ingresos del período */}
+      <StatCard
+        titulo="Ingresos del período"
+        valor={loading ? '—' : formatCOP(metrics.ingresosPeriodo)}
+        descripcion="Total de entradas registradas"
+        variante="positivo"
+        loading={loading}
+        icono={
+          <svg
+            className="w-5 h-5"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={1.8}
+              d="M7 11l5-5m0 0l5 5m-5-5v12"
+            />
+          </svg>
+        }
+      />
+
+      {/* Egresos del período */}
+      <StatCard
+        titulo="Egresos del período"
+        valor={loading ? '—' : formatCOP(metrics.egresosPeriodo)}
+        descripcion="Total de salidas registradas"
+        variante="negativo"
+        loading={loading}
+        icono={
+          <svg
+            className="w-5 h-5"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={1.8}
+              d="M17 13l-5 5m0 0l-5-5m5 5V6"
+            />
+          </svg>
+        }
+      />
+
+      {/* Balance neto */}
+      <StatCard
+        titulo="Balance neto"
+        valor={
+          loading
+            ? '—'
+            : `${balancePositivo ? '+' : ''}${formatCOP(metrics.balanceNeto)}`
+        }
+        descripcion="Ingresos menos egresos del período"
+        variante={balancePositivo ? 'positivo' : 'negativo'}
+        loading={loading}
+        icono={
+          <svg
+            className="w-5 h-5"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={1.8}
+              d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
+            />
+          </svg>
+        }
+      />
+    </div>
+  );
+};
+
+export default CashFlowMetricsGrid;

--- a/frontend/src/features/cash-flow/dashboard/hooks/useCashFlowDashboard.ts
+++ b/frontend/src/features/cash-flow/dashboard/hooks/useCashFlowDashboard.ts
@@ -1,0 +1,112 @@
+import { useMemo } from 'react';
+import type {
+  CierreResumen,
+  CuentaResumen,
+  MovimientoResumen,
+  CashFlowDashboardMetrics,
+  PuntoFlujo,
+} from '../types';
+
+/**
+ * useCashFlowDashboard
+ *
+ * Deriva todas las métricas del dashboard a partir de los datos crudos
+ * de cuentas, movimientos y cierres. Sin efectos secundarios, puro cálculo.
+ */
+export function useCashFlowDashboard(
+  cuentas: CuentaResumen[],
+  movimientos: MovimientoResumen[],
+  cierres: CierreResumen[]
+): CashFlowDashboardMetrics {
+  return useMemo(() => {
+    const saldoTotalDisponible = cuentas.reduce((sum, c) => sum + c.saldo, 0);
+
+    const ingresosPeriodo = movimientos
+      .filter((m) => m.tipo === 'ingreso')
+      .reduce((sum, m) => sum + m.monto, 0);
+
+    const egresosPeriodo = movimientos
+      .filter((m) => m.tipo === 'egreso')
+      .reduce((sum, m) => sum + m.monto, 0);
+
+    const balanceNeto = ingresosPeriodo - egresosPeriodo;
+
+    const cuentasActivas = cuentas.length;
+
+    const cierresPendientes = cierres.filter(
+      (c) => c.estado === 'abierto'
+    ).length;
+
+    // Últimos 5 movimientos ordenados por fecha descendente
+    const movimientosRecientes = [...movimientos]
+      .sort((a, b) => new Date(b.fecha).getTime() - new Date(a.fecha).getTime())
+      .slice(0, 5);
+
+    // Últimos cierres por cuenta (el más reciente de cada cuenta)
+    const ultimosCierresPorCuenta = new Map<string, CierreResumen>();
+    for (const cierre of cierres) {
+      const existing = ultimosCierresPorCuenta.get(cierre.cuentaId);
+      if (
+        !existing ||
+        cierre.año > existing.año ||
+        (cierre.año === existing.año && cierre.mes > existing.mes)
+      ) {
+        ultimosCierresPorCuenta.set(cierre.cuentaId, cierre);
+      }
+    }
+    const ultimosCierres = Array.from(ultimosCierresPorCuenta.values());
+
+    // Puntos de flujo: agrupa movimientos por fecha para el gráfico de línea
+    const puntosPorFecha = new Map<string, PuntoFlujo>();
+    const sortedMovimientos = [...movimientos].sort(
+      (a, b) => new Date(a.fecha).getTime() - new Date(b.fecha).getTime()
+    );
+
+    let saldoAcumulado = saldoTotalDisponible;
+    // Calculamos saldo base yendo hacia atrás
+    for (const m of movimientos) {
+      if (m.tipo === 'ingreso') saldoAcumulado -= m.monto;
+      else saldoAcumulado += m.monto;
+    }
+
+    for (const mov of sortedMovimientos) {
+      const fecha = new Date(mov.fecha);
+      const key = `${fecha.getDate().toString().padStart(2, '0')}/${(fecha.getMonth() + 1).toString().padStart(2, '0')}`;
+
+      if (!puntosPorFecha.has(key)) {
+        puntosPorFecha.set(key, {
+          fecha: key,
+          ingresos: 0,
+          egresos: 0,
+          saldo: saldoAcumulado,
+        });
+      }
+
+      const punto = puntosPorFecha.get(key)!;
+      if (mov.tipo === 'ingreso') {
+        punto.ingresos += mov.monto;
+        saldoAcumulado += mov.monto;
+      } else {
+        punto.egresos += mov.monto;
+        saldoAcumulado -= mov.monto;
+      }
+      punto.saldo = saldoAcumulado;
+    }
+
+    const puntosFlujo = Array.from(puntosPorFecha.values());
+
+    return {
+      saldoTotalDisponible,
+      ingresosPeriodo,
+      egresosPeriodo,
+      balanceNeto,
+      cuentasActivas,
+      cierresPendientes,
+      cuentas,
+      movimientosRecientes,
+      ultimosCierres,
+      puntosFlujo,
+      totalMovimientos: movimientos.length,
+    };
+  }, [cuentas, movimientos, cierres]);
+}

--- a/frontend/src/features/cash-flow/dashboard/hooks/useCashFlowData.ts
+++ b/frontend/src/features/cash-flow/dashboard/hooks/useCashFlowData.ts
@@ -1,0 +1,181 @@
+import { useEffect, useState } from 'react';
+import type { CierreResumen, CuentaResumen, MovimientoResumen } from '../types';
+
+interface CashFlowRawData {
+  cuentas: CuentaResumen[];
+  movimientos: MovimientoResumen[];
+  cierres: CierreResumen[];
+  loading: boolean;
+  error: string | null;
+}
+
+/**
+ * useCashFlowData
+ *
+ * Centraliza el fetch de cuentas, movimientos y cierres del módulo de
+ * Flujo de Caja. Reemplaza las llamadas directas a la API con los
+ * hooks/servicios existentes en el módulo cash-flow.
+ *
+ * TODO: Conectar con los servicios reales del módulo cash-flow.
+ * Por ahora retorna datos de ejemplo para validar la UI.
+ */
+export function useCashFlowData(periodo: string): CashFlowRawData {
+  const [data, setData] = useState<CashFlowRawData>({
+    cuentas: [],
+    movimientos: [],
+    cierres: [],
+    loading: true,
+    error: null,
+  });
+
+  useEffect(() => {
+    // TODO: Reemplazar con llamadas reales a los servicios de cash-flow
+    // Ejemplo:
+    //   const cuentas = await cashFlowService.getCuentas();
+    //   const movimientos = await cashFlowService.getMovimientos({ periodo });
+    //   const cierres = await cashFlowService.getCierres();
+
+    const timer = setTimeout(() => {
+      setData({
+        cuentas: [
+          {
+            id: '1',
+            nombre: 'Banco Bogotá',
+            descripcion: 'cuenta prueba',
+            saldo: 23000000,
+            ingresos: 5000000,
+            egresos: 1000000,
+            cierresPendientes: 1,
+          },
+          {
+            id: '2',
+            nombre: 'Bancolombia',
+            descripcion: 'Cuenta Bancolombia',
+            saldo: 19750000,
+            ingresos: 8000000,
+            egresos: 3000000,
+            cierresPendientes: 0,
+          },
+          {
+            id: '3',
+            nombre: 'Bancolombia Auxiliar',
+            descripcion: 'Cuenta Secundaria Bancolombia',
+            saldo: 12600000,
+            ingresos: 2000000,
+            egresos: 500000,
+            cierresPendientes: 1,
+          },
+          {
+            id: '4',
+            nombre: 'Bancolombia Corriente',
+            descripcion: 'Cuenta corriente de Bancolombia',
+            saldo: 14800000,
+            ingresos: 4000000,
+            egresos: 1500000,
+            cierresPendientes: 0,
+          },
+        ],
+        movimientos: [
+          {
+            id: '1',
+            concepto: 'Factura Messi',
+            descripcion: 'Mejor jugador',
+            cuenta: 'Banco Bogotá',
+            cuentaId: '1',
+            fecha: '2026-05-19',
+            tipo: 'egreso',
+            monto: 1000000,
+          },
+          {
+            id: '2',
+            concepto: 'Probando Pago Lejano',
+            descripcion: 'Pago de prueba',
+            cuenta: 'Bancolombia',
+            cuentaId: '2',
+            fecha: '2026-04-16',
+            tipo: 'egreso',
+            monto: 100000,
+          },
+          {
+            id: '3',
+            concepto: 'Ingreso cliente ABC',
+            descripcion: 'Pago mensual de servicios',
+            cuenta: 'Bancolombia',
+            cuentaId: '2',
+            fecha: '2026-04-10',
+            tipo: 'ingreso',
+            monto: 8000000,
+          },
+          {
+            id: '4',
+            concepto: 'Transferencia interna',
+            descripcion: 'Traslado entre cuentas',
+            cuenta: 'Bancolombia Corriente',
+            cuentaId: '4',
+            fecha: '2026-04-05',
+            tipo: 'ingreso',
+            monto: 4000000,
+          },
+          {
+            id: '5',
+            concepto: 'Pago nómina marzo',
+            descripcion: 'Nómina mensual empleados',
+            cuenta: 'Banco Bogotá',
+            cuentaId: '1',
+            fecha: '2026-03-31',
+            tipo: 'egreso',
+            monto: 500000,
+          },
+        ],
+        cierres: [
+          {
+            id: '1',
+            cuenta: 'Banco Bogotá',
+            cuentaId: '1',
+            periodo: 'Marzo 2026',
+            mes: 3,
+            año: 2026,
+            saldoInicial: 17000000,
+            ingresos: 10000000,
+            egresos: 0,
+            saldoCierre: 27000000,
+            estado: 'abierto',
+          },
+          {
+            id: '2',
+            cuenta: 'Banco Bogotá',
+            cuentaId: '1',
+            periodo: 'Febrero 2026',
+            mes: 2,
+            año: 2026,
+            saldoInicial: 20000000,
+            ingresos: 0,
+            egresos: 3000000,
+            saldoCierre: 17000000,
+            estado: 'cerrado',
+            fechaCierre: '14 de abr de 2026',
+          },
+          {
+            id: '3',
+            cuenta: 'Bancolombia Auxiliar',
+            cuentaId: '3',
+            periodo: 'Marzo 2026',
+            mes: 3,
+            año: 2026,
+            saldoInicial: 11000000,
+            ingresos: 2000000,
+            egresos: 400000,
+            saldoCierre: 12600000,
+            estado: 'abierto',
+          },
+        ],
+        loading: false,
+        error: null,
+      });
+    }, 800);
+
+    return () => clearTimeout(timer);
+  }, [periodo]);
+
+  return data;
+}

--- a/frontend/src/features/cash-flow/dashboard/types/index.ts
+++ b/frontend/src/features/cash-flow/dashboard/types/index.ts
@@ -1,0 +1,62 @@
+export type CashFlowPeriod =
+  | 'mes_actual'
+  | 'ultimos_30'
+  | 'ultimos_90'
+  | 'año_actual';
+
+export interface CuentaResumen {
+  id: string;
+  nombre: string;
+  descripcion?: string;
+  saldo: number;
+  ingresos: number;
+  egresos: number;
+  cierresPendientes: number;
+}
+
+export interface MovimientoResumen {
+  id: string;
+  concepto: string;
+  descripcion?: string;
+  cuenta: string;
+  cuentaId: string;
+  fecha: string;
+  tipo: 'ingreso' | 'egreso';
+  monto: number;
+}
+
+export interface CierreResumen {
+  id: string;
+  cuenta: string;
+  cuentaId: string;
+  periodo: string; // "Marzo 2026"
+  mes: number;
+  año: number;
+  saldoInicial: number;
+  ingresos: number;
+  egresos: number;
+  saldoCierre: number;
+  estado: 'abierto' | 'cerrado';
+  fechaCierre?: string;
+}
+
+export interface PuntoFlujo {
+  fecha: string; // "01/03", "02/03", etc.
+  ingresos: number;
+  egresos: number;
+  saldo: number;
+}
+
+export interface CashFlowDashboardMetrics {
+  saldoTotalDisponible: number;
+  ingresosPeriodo: number;
+  egresosPeriodo: number;
+  balanceNeto: number;
+  cuentasActivas: number;
+  cierresPendientes: number;
+  cuentas: CuentaResumen[];
+  movimientosRecientes: MovimientoResumen[];
+  ultimosCierres: CierreResumen[];
+  puntosFlujo: PuntoFlujo[];
+  totalMovimientos: number;
+}

--- a/frontend/src/features/dashboard/components/DomainSwitcher.tsx
+++ b/frontend/src/features/dashboard/components/DomainSwitcher.tsx
@@ -1,5 +1,4 @@
-import { Briefcase, Building2 } from 'lucide-react';
-
+import type { FC } from 'react';
 import type { DashboardDomain } from '../types';
 
 interface DomainSwitcherProps {
@@ -7,34 +6,76 @@ interface DomainSwitcherProps {
   onChange: (domain: DashboardDomain) => void;
 }
 
-export default function DomainSwitcher({
+const DOMINIOS: {
+  id: DashboardDomain;
+  label: string;
+  icono: React.ReactNode;
+}[] = [
+  {
+    id: 'family_office',
+    label: 'Family Office',
+    icono: (
+      <svg
+        className="w-4 h-4"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={1.8}
+          d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
+        />
+      </svg>
+    ),
+  },
+  {
+    id: 'cole_co',
+    label: 'Cole & Co',
+    icono: (
+      <svg
+        className="w-4 h-4"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={1.8}
+          d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z"
+        />
+      </svg>
+    ),
+  },
+];
+
+const DomainSwitcher: FC<DomainSwitcherProps> = ({
   activeDashboardDomain,
   onChange,
-}: DomainSwitcherProps) {
+}) => {
   return (
-    <div className="mb-6 inline-flex items-center gap-1 p-1 bg-neutral-surface border border-neutral-border rounded-xl">
-      <button
-        onClick={() => onChange('family_office')}
-        className={`inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200 ${
-          activeDashboardDomain === 'family_office'
-            ? 'bg-primary text-white shadow-sm'
-            : 'text-neutral-muted hover:text-neutral-text'
-        }`}
-      >
-        <Briefcase size={14} />
-        Family Office
-      </button>
-      <button
-        onClick={() => onChange('cole_co')}
-        className={`inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200 ${
-          activeDashboardDomain === 'cole_co'
-            ? 'bg-primary text-white shadow-sm'
-            : 'text-neutral-muted hover:text-neutral-text'
-        }`}
-      >
-        <Building2 size={14} />
-        COLE-CO
-      </button>
+    <div className="flex gap-2 mb-6 p-1 bg-neutral-100 rounded-xl w-fit">
+      {DOMINIOS.map((dominio) => {
+        const activo = activeDashboardDomain === dominio.id;
+        return (
+          <button
+            key={dominio.id}
+            onClick={() => onChange(dominio.id)}
+            className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-all ${
+              activo
+                ? 'bg-white text-neutral-900 shadow-sm'
+                : 'text-neutral-500 hover:text-neutral-700'
+            }`}
+          >
+            {dominio.icono}
+            {dominio.label}
+          </button>
+        );
+      })}
     </div>
   );
-}
+};
+
+export default DomainSwitcher;

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -3,7 +3,6 @@ import { AuthContext } from '../context/AuthContext';
 import { useCompany } from '../context/CompanyContext';
 import { useNavigate } from 'react-router-dom';
 
-import ColeCoDashboard from '../features/dashboard/components/ColeCoDashboard';
 import ChartsRow from '../features/dashboard/components/ChartsRow';
 import DateRangeSelector from '../features/dashboard/components/DateRangeSelector';
 import DomainSwitcher from '../features/dashboard/components/DomainSwitcher';
@@ -11,6 +10,7 @@ import FamilyOfficeHeader from '../features/dashboard/components/FamilyOfficeHea
 import MetricsGrid from '../features/dashboard/components/MetricsGrid';
 import NoDashboardAccess from '../features/dashboard/components/NoDashboardAccess';
 import PriorityList from '../features/dashboard/components/PriorityList';
+import CashFlowDashboard from '../features/cash-flow/dashboard/components/CashFlowDashboard';
 import { useDashboardData } from '../features/dashboard/hooks/useDashboardData';
 import { useDashboardMetrics } from '../features/dashboard/hooks/useDashboardMetrics';
 import type {
@@ -52,6 +52,7 @@ const DashboardPage = () => {
 
   const canSeeColeCoDashboard =
     (isAdmin || isColeCoRole) && activeDashboardDomain === 'cole_co';
+
   const { deadlines, loading, error } = useDashboardData(
     canSeeFamilyOfficeDashboard
   );
@@ -83,14 +84,6 @@ const DashboardPage = () => {
           />
         )}
 
-        {canSeeColeCoDashboard && (
-          <ColeCoDashboard
-            currentDateText={currentDateText}
-            fullName={user?.full_name ?? undefined}
-            role={user?.role}
-          />
-        )}
-
         {canSeeFamilyOfficeDashboard && (
           <>
             <FamilyOfficeHeader
@@ -117,6 +110,18 @@ const DashboardPage = () => {
               onViewAll={() => navigate('/family-office?tab=vencimientos')}
             />
           </>
+        )}
+
+        {canSeeColeCoDashboard && (
+          <CashFlowDashboard
+            currentDateText={currentDateText}
+            fullName={user?.full_name ?? undefined}
+            onIrAMovimientos={() => navigate('/flujo-de-caja?tab=movimientos')}
+            onIrACierres={() => navigate('/flujo-de-caja?tab=cierre')}
+            onVerCuenta={(cuentaId) =>
+              navigate(`/flujo-de-caja?tab=movimientos&cuenta=${cuentaId}`)
+            }
+          />
         )}
       </div>
     </div>


### PR DESCRIPTION
## Objetivo
Implementar el dashboard del módulo Flujo de Caja para el rol contador_cole_co. Muestra un resumen visual de cuentas activas, movimientos, distribución de saldo y estado de cierres mensuales, siguiendo la misma estructura y sistema de diseño del dashboard de Family Office.

## Cambios Principales

- **CashFlowDashboard:** Componente orquestador principal que compone todos los sub-componentes del dashboard. Recibe props de navegación para redirigir a movimientos, cierres y cuentas específicas

- **CashFlowDashboardHeader:** Header con saludo al usuario, fecha actual y acceso rápido a "Registrar movimiento"

- **CashFlowMetricsGrid:** Grid de 4 tarjetas — Saldo Total Disponible, Ingresos del Período, Egresos del Período y Balance Neto — con skeleton completo que reemplaza título, ícono y valor durante la carga

- **CashFlowChartsRow:** Dos gráficos lado a lado — área chart de flujo de ingresos vs egresos en el tiempo (Recharts AreaChart) y donut de distribución de saldo por cuenta (PieChart). Ambos con skeleton completo del card incluyendo header

- **CashFlowAccountsGrid:** Grid de tarjetas por cuenta con borde de color distintivo, saldo individual, ingresos/egresos del período e indicador de cierre pendiente. Clickeable para navegar a la cuenta

- **CashFlowActivityPanel**: Panel doble — movimientos recientes ordenados por fecha y estado del último cierre mensual por cuenta, con skeleton de filas completo

- **useCashFlowData:** Hook de fetch centralizado con datos mock listos para reemplazar con los servicios reales del módulo.

- **useCashFlowDashboard:** Hook de cálculo puro de métricas (saldo total, ingresos, egresos, balance neto, puntos de flujo para el gráfico, cierres por cuenta) derivado desde los datos crudos sin efectos secundarios

- **types/index.ts:** Tipos TypeScript completos — CuentaResumen, MovimientoResumen, CierreResumen, PuntoFlujo, CashFlowDashboardMetrics

- **DashboardPage:** El rol contador_cole_co ahora activa canSeeColeCoDashboard que renderiza CashFlowDashboard. Eliminado el placeholder ColeCoDashboard. Rutas apuntan a /flujo-de-caja

- **DomainSwitcher:** Simplificado a 2 pestañas (Family Office / Cole & Co), eliminada la pestaña "Flujo de Caja" como dominio separado


## Como Probarlo

1. Iniciar sesión con un usuario de rol contador_cole_co
2. El dashboard debe mostrar el skeleton animado durante ~800ms y luego los datos mock
3. Verificar las 4 tarjetas superiores con valores en negro
4. Verificar el área chart con ingresos (verde) y egresos (rojo)
5. Verificar el donut con distribución por cuenta y leyenda centrada abajo
6. Verificar el grid de cuentas con bordes de color y badge "Cierre pendiente" donde aplique
7. Verificar movimientos recientes ordenados por fecha descendente
8. Verificar estado de cierres con badge Abierto/Cerrado
9. Clic en una cuenta del grid — debe navegar a /flujo-de-caja
10. Clic en "Registrar movimiento" — debe navegar a /flujo-de-caja
11. Si el usuario es admin, el DomainSwitcher debe mostrar solo 2 pestañas


## Notas

- Los datos en useCashFlowData son mock — conectar con los servicios reales de cash-flow antes de merge a producción. Los puntos // TODO marcan exactamente dónde hacer el reemplazo
- El componente ColeCoDashboard existente puede eliminarse del proyecto si no tiene otros usos
- Los skeletons siguen exactamente el mismo patrón de CardSkeleton y ChartSkeleton del dashboard de Family Office (bg-neutral-border, animate-pulse, proporciones idénticas)
- No hay dependencias nuevas — usa Recharts que ya estaba instalado