### PR TITLE
feat: gestión de pagos de Cole&Co (HU-021)

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -26,6 +26,7 @@ from src.modules.family_office.companies import models as company_models
 from src.modules.family_office.balances import models as balance_models
 from src.modules.family_office.deadlines import models as deadline_models
 from src.modules.cole_co.cash_flow import models as cash_flow_models
+from src.modules.cole_co.payments import models as payment_models
 # =================================================================
 
 

--- a/backend/alembic/versions/c3d5e7f9a1b2_add_payments_table.py
+++ b/backend/alembic/versions/c3d5e7f9a1b2_add_payments_table.py
@@ -1,0 +1,55 @@
+"""add payments table
+
+Revision ID: c3d5e7f9a1b2
+Revises: a1b2c3d4e5f6
+Create Date: 2026-04-18 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c3d5e7f9a1b2"
+down_revision: Union[str, None] = "a1b2c3d4e5f6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "payments",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("concept", sa.String(), nullable=False),
+        sa.Column("description", sa.String(), nullable=False),
+        sa.Column("amount", sa.Numeric(14, 2), nullable=False),
+        sa.Column("due_date", sa.Date(), nullable=False),
+        sa.Column(
+            "status",
+            sa.Enum("pendiente", "pagado", name="paymentstatus"),
+            nullable=False,
+            server_default="pendiente",
+        ),
+        sa.Column("paid_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_payments_id", "payments", ["id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_payments_id", table_name="payments")
+    op.drop_table("payments")
+    op.execute("DROP TYPE IF EXISTS paymentstatus")

--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -3,6 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from src.modules.auth.router import router as auth_router
 from src.modules.cole_co.cash_flow.router import router as cash_flow_router
+from src.modules.cole_co.payments.router import router as payments_router
 from src.modules.family_office.balances.router import router as balances_router
 from src.modules.family_office.companies.router import router as companies_router
 from src.modules.family_office.deadlines.router import router as deadlines_router
@@ -22,6 +23,7 @@ app.add_middleware(
 
 app.include_router(auth_router)
 app.include_router(cash_flow_router)
+app.include_router(payments_router)
 app.include_router(companies_router)
 app.include_router(balances_router)
 app.include_router(deadlines_router)

--- a/backend/src/modules/cole_co/payments/models.py
+++ b/backend/src/modules/cole_co/payments/models.py
@@ -1,0 +1,46 @@
+import enum
+
+from sqlalchemy import (
+    Column,
+    Date,
+    DateTime,
+    Integer,
+    Numeric,
+    String,
+    func,
+)
+from sqlalchemy import Enum as SqlEnum
+
+from src.core.database import Base
+
+
+class PaymentStatus(str, enum.Enum):
+    PENDIENTE = "pendiente"
+    PAGADO = "pagado"
+
+
+class Payment(Base):
+    __tablename__ = "payments"
+
+    id = Column(Integer, primary_key=True, index=True)
+    concept = Column(String, nullable=False)
+    description = Column(String, nullable=False)
+    amount = Column(Numeric(14, 2), nullable=False)
+    due_date = Column(Date, nullable=False)
+    status = Column(
+        SqlEnum(
+            PaymentStatus, values_callable=lambda values: [v.value for v in values]
+        ),
+        default=PaymentStatus.PENDIENTE,
+        nullable=False,
+    )
+    paid_at = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )

--- a/backend/src/modules/cole_co/payments/router.py
+++ b/backend/src/modules/cole_co/payments/router.py
@@ -1,0 +1,65 @@
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.orm import Session
+
+from src.core.database import get_db
+from src.modules.auth import dependencies as auth_dependencies
+from src.modules.auth import models as auth_models
+
+from . import schemas, service
+
+router = APIRouter(prefix="/payments", tags=["Payments"])
+
+ALLOWED_ROLES = [
+    auth_models.UserRole.ADMIN,
+    auth_models.UserRole.CONTADOR_COLE_CO,
+]
+
+
+@router.get("/", response_model=list[schemas.PaymentResponse])
+def get_payments(
+    db: Session = Depends(get_db),
+    current_user=Depends(auth_dependencies.require_role(ALLOWED_ROLES)),
+):
+    return service.list_payments(db)
+
+
+@router.post(
+    "/",
+    response_model=schemas.PaymentResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_payment(
+    payload: schemas.PaymentCreate,
+    db: Session = Depends(get_db),
+    current_user=Depends(auth_dependencies.require_role(ALLOWED_ROLES)),
+):
+    return service.create_payment(db, payload)
+
+
+@router.put("/{payment_id}", response_model=schemas.PaymentResponse)
+def update_payment(
+    payment_id: int,
+    payload: schemas.PaymentUpdate,
+    db: Session = Depends(get_db),
+    current_user=Depends(auth_dependencies.require_role(ALLOWED_ROLES)),
+):
+    return service.update_payment(db, payment_id, payload)
+
+
+@router.patch("/{payment_id}/mark-paid", response_model=schemas.PaymentResponse)
+def mark_payment_as_paid(
+    payment_id: int,
+    db: Session = Depends(get_db),
+    current_user=Depends(auth_dependencies.require_role(ALLOWED_ROLES)),
+):
+    return service.mark_as_paid(db, payment_id)
+
+
+@router.delete("/{payment_id}", status_code=status.HTTP_200_OK)
+def delete_payment(
+    payment_id: int,
+    db: Session = Depends(get_db),
+    current_user=Depends(auth_dependencies.require_role(ALLOWED_ROLES)),
+):
+    service.delete_payment(db, payment_id)
+    return {"message": "Pago eliminado correctamente"}

--- a/backend/src/modules/cole_co/payments/schemas.py
+++ b/backend/src/modules/cole_co/payments/schemas.py
@@ -1,0 +1,34 @@
+from datetime import date, datetime
+from decimal import Decimal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .models import PaymentStatus
+
+
+class PaymentCreate(BaseModel):
+    concept: str = Field(..., min_length=2, max_length=120)
+    description: str = Field(..., min_length=2, max_length=500)
+    amount: Decimal = Field(..., gt=0)
+    due_date: date
+
+
+class PaymentUpdate(BaseModel):
+    concept: str | None = Field(default=None, min_length=2, max_length=120)
+    description: str | None = Field(default=None, min_length=2, max_length=500)
+    amount: Decimal | None = Field(default=None, gt=0)
+    due_date: date | None = None
+
+
+class PaymentResponse(BaseModel):
+    id: int
+    concept: str
+    description: str
+    amount: Decimal
+    due_date: date
+    status: PaymentStatus
+    paid_at: datetime | None = None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/src/modules/cole_co/payments/service.py
+++ b/backend/src/modules/cole_co/payments/service.py
@@ -34,9 +34,7 @@ def create_payment(db: Session, payload: schemas.PaymentCreate):
 
 
 def _get_payment(db: Session, payment_id: int):
-    payment = (
-        db.query(models.Payment).filter(models.Payment.id == payment_id).first()
-    )
+    payment = db.query(models.Payment).filter(models.Payment.id == payment_id).first()
     if not payment:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/backend/src/modules/cole_co/payments/service.py
+++ b/backend/src/modules/cole_co/payments/service.py
@@ -1,0 +1,87 @@
+from fastapi import HTTPException, status
+from sqlalchemy import case, func
+from sqlalchemy.orm import Session
+
+from . import models, schemas
+
+
+def list_payments(db: Session):
+    return (
+        db.query(models.Payment)
+        .order_by(
+            case(
+                (models.Payment.status == models.PaymentStatus.PENDIENTE, 0),
+                else_=1,
+            ),
+            models.Payment.due_date.asc(),
+        )
+        .all()
+    )
+
+
+def create_payment(db: Session, payload: schemas.PaymentCreate):
+    payment = models.Payment(
+        concept=payload.concept.strip(),
+        description=payload.description.strip(),
+        amount=payload.amount,
+        due_date=payload.due_date,
+        status=models.PaymentStatus.PENDIENTE,
+    )
+    db.add(payment)
+    db.commit()
+    db.refresh(payment)
+    return payment
+
+
+def _get_payment(db: Session, payment_id: int):
+    payment = (
+        db.query(models.Payment).filter(models.Payment.id == payment_id).first()
+    )
+    if not payment:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="El pago no existe",
+        )
+    return payment
+
+
+def update_payment(db: Session, payment_id: int, payload: schemas.PaymentUpdate):
+    payment = _get_payment(db, payment_id)
+
+    if payment.status == models.PaymentStatus.PAGADO:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No se puede editar un pago que ya fue marcado como pagado",
+        )
+
+    for key, value in payload.model_dump(exclude_unset=True).items():
+        if isinstance(value, str):
+            value = value.strip()
+        setattr(payment, key, value)
+
+    db.commit()
+    db.refresh(payment)
+    return payment
+
+
+def mark_as_paid(db: Session, payment_id: int):
+    payment = _get_payment(db, payment_id)
+
+    if payment.status == models.PaymentStatus.PAGADO:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Este pago ya fue marcado como pagado",
+        )
+
+    payment.status = models.PaymentStatus.PAGADO
+    payment.paid_at = db.execute(func.now()).scalar()
+    db.commit()
+    db.refresh(payment)
+    return payment
+
+
+def delete_payment(db: Session, payment_id: int):
+    payment = _get_payment(db, payment_id)
+    db.delete(payment)
+    db.commit()
+    return payment

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import React from 'react';
 import SettingsPage from './pages/SettingsPage';
 import NotificationsPage from './pages/NotificationsPage';
 import CashFlowPage from './pages/CashFlowPage';
+import PaymentsPage from './pages/PaymentsPage';
 
 function LayoutWithSidebar({ children }: { children: React.ReactNode }) {
   return (
@@ -67,6 +68,16 @@ function App() {
             <ProtectedRoute>
               <LayoutWithSidebar>
                 <CashFlowPage />
+              </LayoutWithSidebar>
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/pagos"
+          element={
+            <ProtectedRoute>
+              <LayoutWithSidebar>
+                <PaymentsPage />
               </LayoutWithSidebar>
             </ProtectedRoute>
           }

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -7,6 +7,7 @@ import {
   LayoutDashboard,
   Briefcase,
   ArrowLeftRight,
+  CreditCard,
   FileText,
   BarChart2,
   Settings,
@@ -34,6 +35,12 @@ const mainItems = [
     icon: ArrowLeftRight,
     path: '/flujo-de-caja',
     roles: ['admin', 'contador_family_office', 'contador_cole_co'],
+  },
+  {
+    label: 'Pagos',
+    icon: CreditCard,
+    path: '/pagos',
+    roles: ['admin', 'contador_cole_co'],
   },
   {
     label: 'Facturas',

--- a/frontend/src/features/payments/components/DeleteConfirmDialog.tsx
+++ b/frontend/src/features/payments/components/DeleteConfirmDialog.tsx
@@ -1,0 +1,46 @@
+import { AlertTriangle } from 'lucide-react';
+
+interface DeleteConfirmDialogProps {
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export default function DeleteConfirmDialog({
+  onConfirm,
+  onCancel,
+}: DeleteConfirmDialogProps) {
+  return (
+    <div className="fixed inset-0 bg-black/40 z-50 flex items-center justify-center">
+      <div className="bg-white rounded-2xl p-6 shadow-xl max-w-sm w-full mx-4 text-center">
+        <div className="flex justify-center mb-3">
+          <div className="w-12 h-12 rounded-full bg-danger/10 flex items-center justify-center">
+            <AlertTriangle size={24} className="text-danger" />
+          </div>
+        </div>
+
+        <h3 className="text-sm font-semibold text-neutral-text mb-1">
+          Eliminar pago
+        </h3>
+        <p className="text-xs text-neutral-muted mb-5">
+          Esta accion no se puede deshacer. El registro del pago se eliminara
+          permanentemente.
+        </p>
+
+        <div className="flex gap-2">
+          <button
+            onClick={onCancel}
+            className="flex-1 rounded-lg border border-neutral-border text-sm py-2.5 text-neutral-text hover:bg-neutral-bg transition-colors"
+          >
+            Cancelar
+          </button>
+          <button
+            onClick={onConfirm}
+            className="flex-1 rounded-lg bg-danger text-white text-sm py-2.5 hover:bg-red-600 transition-colors"
+          >
+            Eliminar
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/payments/components/EditPaymentModal.tsx
+++ b/frontend/src/features/payments/components/EditPaymentModal.tsx
@@ -72,9 +72,7 @@ export default function EditPaymentModal({
           </div>
 
           <div>
-            <label className="text-xs text-neutral-muted">
-              Fecha limite *
-            </label>
+            <label className="text-xs text-neutral-muted">Fecha limite *</label>
             <input
               type="date"
               value={editForm.due_date}

--- a/frontend/src/features/payments/components/EditPaymentModal.tsx
+++ b/frontend/src/features/payments/components/EditPaymentModal.tsx
@@ -1,0 +1,108 @@
+import { X } from 'lucide-react';
+import type { FormEvent } from 'react';
+
+import type { PaymentFormState } from '../types';
+
+interface EditPaymentModalProps {
+  editForm: PaymentFormState;
+  onChange: (next: PaymentFormState) => void;
+  saving: boolean;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => Promise<void>;
+  onCancel: () => void;
+}
+
+export default function EditPaymentModal({
+  editForm,
+  onChange,
+  saving,
+  onSubmit,
+  onCancel,
+}: EditPaymentModalProps) {
+  return (
+    <div className="fixed inset-0 bg-black/40 z-50 flex items-center justify-center">
+      <div className="bg-white rounded-2xl p-6 shadow-xl max-w-lg w-full mx-4">
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-sm font-semibold text-neutral-text">
+            Editar pago
+          </h3>
+          <button
+            onClick={onCancel}
+            className="text-neutral-muted hover:text-neutral-text transition-colors"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        <form className="space-y-3" onSubmit={onSubmit}>
+          <div>
+            <label className="text-xs text-neutral-muted">Concepto *</label>
+            <input
+              value={editForm.concept}
+              onChange={(e) =>
+                onChange({ ...editForm, concept: e.target.value })
+              }
+              className="w-full mt-1 rounded-lg border border-neutral-border bg-white px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary/30"
+            />
+          </div>
+
+          <div>
+            <label className="text-xs text-neutral-muted">Descripcion *</label>
+            <textarea
+              value={editForm.description}
+              onChange={(e) =>
+                onChange({ ...editForm, description: e.target.value })
+              }
+              className="w-full mt-1 rounded-lg border border-neutral-border bg-white px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary/30"
+              rows={2}
+            />
+          </div>
+
+          <div>
+            <label className="text-xs text-neutral-muted">Monto *</label>
+            <input
+              type="number"
+              min="0.01"
+              step="0.01"
+              value={editForm.amount}
+              onChange={(e) =>
+                onChange({ ...editForm, amount: e.target.value })
+              }
+              className="w-full mt-1 rounded-lg border border-neutral-border bg-white px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary/30"
+            />
+          </div>
+
+          <div>
+            <label className="text-xs text-neutral-muted">
+              Fecha limite *
+            </label>
+            <input
+              type="date"
+              value={editForm.due_date}
+              onChange={(e) =>
+                onChange({ ...editForm, due_date: e.target.value })
+              }
+              className="w-full mt-1 rounded-lg border border-neutral-border bg-white px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary/30"
+            />
+          </div>
+
+          <div className="flex gap-2 pt-2">
+            <button
+              type="button"
+              onClick={onCancel}
+              className="flex-1 rounded-lg border border-neutral-border text-sm py-2.5 text-neutral-text hover:bg-neutral-bg transition-colors"
+            >
+              Cancelar
+            </button>
+            <button
+              type="submit"
+              disabled={saving}
+              className="flex-1 rounded-lg bg-primary text-white text-sm py-2.5 disabled:opacity-50"
+            >
+              {saving ? 'Guardando...' : 'Guardar cambios'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/payments/components/NewPaymentCard.tsx
+++ b/frontend/src/features/payments/components/NewPaymentCard.tsx
@@ -1,0 +1,100 @@
+import { CreditCard } from 'lucide-react';
+import type { FormEvent } from 'react';
+
+import type { PaymentFormState } from '../types';
+
+interface NewPaymentCardProps {
+  paymentForm: PaymentFormState;
+  onChange: (next: PaymentFormState) => void;
+  error: string | null;
+  saving: boolean;
+  canSave: boolean;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => Promise<void>;
+}
+
+export default function NewPaymentCard({
+  paymentForm,
+  onChange,
+  error,
+  saving,
+  canSave,
+  onSubmit,
+}: NewPaymentCardProps) {
+  return (
+    <article className="rounded-2xl border border-neutral-border bg-neutral-surface p-6 shadow-sm xl:col-span-1">
+      <div className="flex items-center gap-2 mb-4 text-neutral-text">
+        <CreditCard size={18} />
+        <h2 className="text-sm font-semibold">Nuevo pago</h2>
+      </div>
+
+      <form className="space-y-3" onSubmit={onSubmit}>
+        <div>
+          <label className="text-xs text-neutral-muted">Concepto *</label>
+          <input
+            value={paymentForm.concept}
+            onChange={(e) =>
+              onChange({ ...paymentForm, concept: e.target.value })
+            }
+            className="w-full mt-1 rounded-lg border border-neutral-border bg-white px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary/30"
+            placeholder="Ej: Arriendo oficina"
+          />
+        </div>
+
+        <div>
+          <label className="text-xs text-neutral-muted">Descripcion *</label>
+          <textarea
+            value={paymentForm.description}
+            onChange={(e) =>
+              onChange({ ...paymentForm, description: e.target.value })
+            }
+            className="w-full mt-1 rounded-lg border border-neutral-border bg-white px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary/30"
+            rows={2}
+            placeholder="Detalle del pago"
+          />
+        </div>
+
+        <div>
+          <label className="text-xs text-neutral-muted">Monto *</label>
+          <input
+            type="number"
+            min="0.01"
+            step="0.01"
+            value={paymentForm.amount}
+            onChange={(e) =>
+              onChange({ ...paymentForm, amount: e.target.value })
+            }
+            className="w-full mt-1 rounded-lg border border-neutral-border bg-white px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary/30"
+            placeholder="0"
+          />
+        </div>
+
+        <div>
+          <label className="text-xs text-neutral-muted">Fecha limite *</label>
+          <input
+            type="date"
+            value={paymentForm.due_date}
+            onChange={(e) =>
+              onChange({ ...paymentForm, due_date: e.target.value })
+            }
+            className="w-full mt-1 rounded-lg border border-neutral-border bg-white px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary/30"
+          />
+        </div>
+
+        {error && (
+          <p className="text-xs text-danger bg-danger/10 border border-danger/20 rounded-md px-2 py-1">
+            {error}
+          </p>
+        )}
+
+        <button
+          disabled={!canSave || saving}
+          className="w-full rounded-lg bg-primary text-white text-sm py-2.5 disabled:bg-primary disabled:opacity-100 disabled:cursor-not-allowed"
+        >
+          <span className="inline-flex items-center justify-center min-w-[120px]">
+            {saving ? 'Guardando...' : 'Crear pago'}
+          </span>
+        </button>
+      </form>
+    </article>
+  );
+}

--- a/frontend/src/features/payments/components/PaymentsSkeleton.tsx
+++ b/frontend/src/features/payments/components/PaymentsSkeleton.tsx
@@ -1,0 +1,43 @@
+export default function PaymentsSkeleton() {
+  return (
+    <div className="space-y-6 animate-pulse">
+      <section className="grid grid-cols-1 xl:grid-cols-3 gap-6">
+        <article className="rounded-2xl border border-neutral-border bg-neutral-surface p-6 shadow-sm min-h-[360px] xl:col-span-1">
+          <div className="flex items-center gap-2 mb-4">
+            <div className="w-4 h-4 rounded bg-neutral-border" />
+            <div className="h-4 w-28 bg-neutral-border rounded" />
+          </div>
+          <div className="space-y-3">
+            <div className="space-y-1">
+              <div className="h-3 w-20 bg-neutral-border rounded" />
+              <div className="h-10 w-full bg-neutral-border/70 rounded-lg" />
+            </div>
+            <div className="space-y-1">
+              <div className="h-3 w-24 bg-neutral-border rounded" />
+              <div className="h-20 w-full bg-neutral-border/70 rounded-lg" />
+            </div>
+            <div className="space-y-1">
+              <div className="h-3 w-16 bg-neutral-border rounded" />
+              <div className="h-10 w-full bg-neutral-border/70 rounded-lg" />
+            </div>
+            <div className="space-y-1">
+              <div className="h-3 w-24 bg-neutral-border rounded" />
+              <div className="h-10 w-full bg-neutral-border/70 rounded-lg" />
+            </div>
+            <div className="h-10 w-full bg-neutral-border rounded-lg" />
+          </div>
+        </article>
+
+        <article className="rounded-2xl border border-neutral-border bg-neutral-surface p-6 shadow-sm min-h-[360px] xl:col-span-2">
+          <div className="h-4 w-36 bg-neutral-border rounded mb-4" />
+          <div className="space-y-3">
+            <div className="h-12 bg-neutral-border/70 rounded-xl" />
+            <div className="h-12 bg-neutral-border/70 rounded-xl" />
+            <div className="h-12 bg-neutral-border/70 rounded-xl" />
+            <div className="h-12 bg-neutral-border/70 rounded-xl" />
+          </div>
+        </article>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/features/payments/components/PaymentsTable.tsx
+++ b/frontend/src/features/payments/components/PaymentsTable.tsx
@@ -86,9 +86,9 @@ export default function PaymentsTable({
                     {currency.format(Number(payment.amount))}
                   </td>
                   <td className="px-4 py-3 text-neutral-muted whitespace-nowrap">
-                    {new Date(payment.due_date + 'T00:00:00').toLocaleDateString(
-                      'es-CO'
-                    )}
+                    {new Date(
+                      payment.due_date + 'T00:00:00'
+                    ).toLocaleDateString('es-CO')}
                   </td>
                   <td className="px-4 py-3">
                     <span

--- a/frontend/src/features/payments/components/PaymentsTable.tsx
+++ b/frontend/src/features/payments/components/PaymentsTable.tsx
@@ -1,0 +1,138 @@
+import { CheckCircle, Pencil, Trash2 } from 'lucide-react';
+
+import type { Payment } from '../../../services/paymentsService';
+import { currency, getTrafficLight } from '../types';
+
+interface PaymentsTableProps {
+  payments: Payment[];
+  onMarkPaid: (id: number) => void;
+  onEdit: (payment: Payment) => void;
+  onDelete: (id: number) => void;
+}
+
+const trafficStyles = {
+  red: {
+    badge: 'bg-red-100 text-red-700 border border-red-200',
+    row: 'border-l-4 border-l-red-400',
+    label: 'Vencido',
+  },
+  yellow: {
+    badge: 'bg-amber-100 text-amber-700 border border-amber-200',
+    row: 'border-l-4 border-l-amber-400',
+    label: 'Pendiente',
+  },
+  gray: {
+    badge: 'bg-neutral-100 text-neutral-500 border border-neutral-200',
+    row: 'border-l-4 border-l-neutral-300',
+    label: 'Pagado',
+  },
+};
+
+export default function PaymentsTable({
+  payments,
+  onMarkPaid,
+  onEdit,
+  onDelete,
+}: PaymentsTableProps) {
+  if (payments.length === 0) {
+    return (
+      <article className="rounded-2xl border border-neutral-border bg-neutral-surface p-6 shadow-sm xl:col-span-2">
+        <h2 className="text-sm font-semibold text-neutral-text mb-4">
+          Pagos registrados
+        </h2>
+        <p className="text-sm text-neutral-muted text-center py-8">
+          No hay pagos registrados aun. Crea uno desde el formulario.
+        </p>
+      </article>
+    );
+  }
+
+  return (
+    <article className="rounded-2xl border border-neutral-border bg-neutral-surface p-6 shadow-sm xl:col-span-2">
+      <h2 className="text-sm font-semibold text-neutral-text mb-4">
+        Pagos registrados
+      </h2>
+
+      <div className="overflow-x-auto rounded-xl border border-neutral-border bg-white">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-neutral-border bg-neutral-bg/50 text-left text-xs text-neutral-muted">
+              <th className="px-4 py-3 font-medium">Concepto</th>
+              <th className="px-4 py-3 font-medium">Monto</th>
+              <th className="px-4 py-3 font-medium">Fecha limite</th>
+              <th className="px-4 py-3 font-medium">Estado</th>
+              <th className="px-4 py-3 font-medium text-right">Acciones</th>
+            </tr>
+          </thead>
+          <tbody>
+            {payments.map((payment) => {
+              const light = getTrafficLight(payment.status, payment.due_date);
+              const styles = trafficStyles[light];
+
+              return (
+                <tr
+                  key={payment.id}
+                  className={`border-b border-neutral-border last:border-b-0 hover:bg-neutral-bg/30 transition-colors ${styles.row}`}
+                >
+                  <td className="px-4 py-3">
+                    <p className="font-medium text-neutral-text">
+                      {payment.concept}
+                    </p>
+                    <p className="text-xs text-neutral-muted mt-0.5 line-clamp-1">
+                      {payment.description}
+                    </p>
+                  </td>
+                  <td className="px-4 py-3 font-medium text-neutral-text whitespace-nowrap">
+                    {currency.format(Number(payment.amount))}
+                  </td>
+                  <td className="px-4 py-3 text-neutral-muted whitespace-nowrap">
+                    {new Date(payment.due_date + 'T00:00:00').toLocaleDateString(
+                      'es-CO'
+                    )}
+                  </td>
+                  <td className="px-4 py-3">
+                    <span
+                      className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium ${styles.badge}`}
+                    >
+                      {styles.label}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex items-center justify-end gap-1.5">
+                      {payment.status === 'pendiente' && (
+                        <>
+                          <button
+                            onClick={() => onMarkPaid(payment.id)}
+                            title="Marcar como pagado"
+                            className="rounded-lg bg-emerald-600 text-white px-2.5 py-1.5 text-xs font-medium hover:bg-emerald-700 transition-colors inline-flex items-center gap-1"
+                          >
+                            <CheckCircle size={13} />
+                            Pagado
+                          </button>
+                          <button
+                            onClick={() => onEdit(payment)}
+                            title="Editar"
+                            className="rounded-lg border border-neutral-border px-2 py-1.5 text-neutral-muted hover:text-neutral-text hover:bg-neutral-bg transition-colors"
+                          >
+                            <Pencil size={14} />
+                          </button>
+                        </>
+                      )}
+                      <button
+                        onClick={() => onDelete(payment.id)}
+                        title="Eliminar"
+                        className="rounded-lg border border-neutral-border px-2 py-1.5 text-neutral-muted hover:text-danger hover:border-danger/30 transition-colors"
+                      >
+                        <Trash2 size={14} />
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </article>
+  );
+}

--- a/frontend/src/features/payments/components/PaymentsToasts.tsx
+++ b/frontend/src/features/payments/components/PaymentsToasts.tsx
@@ -1,0 +1,42 @@
+interface ToastItem {
+  id: number;
+  type: 'success' | 'error';
+  message: string;
+}
+
+interface PaymentsToastsProps {
+  toasts: ToastItem[];
+  onDismiss: (id: number) => void;
+}
+
+export default function PaymentsToasts({
+  toasts,
+  onDismiss,
+}: PaymentsToastsProps) {
+  if (toasts.length === 0) return null;
+
+  return (
+    <div className="fixed top-5 right-5 z-50 space-y-2">
+      {toasts.map((toast) => (
+        <div
+          key={toast.id}
+          className={`min-w-[300px] max-w-[360px] rounded-lg border px-4 py-3 shadow-lg bg-white ${
+            toast.type === 'success'
+              ? 'border-emerald-300 text-emerald-800'
+              : 'border-danger/40 text-danger'
+          }`}
+        >
+          <div className="flex items-start justify-between gap-4">
+            <p className="text-sm font-medium">{toast.message}</p>
+            <button
+              onClick={() => onDismiss(toast.id)}
+              className="text-xs opacity-70 hover:opacity-100"
+            >
+              Cerrar
+            </button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/features/payments/hooks/usePaymentsData.ts
+++ b/frontend/src/features/payments/hooks/usePaymentsData.ts
@@ -1,0 +1,212 @@
+import { useEffect, useState } from 'react';
+import type { FormEvent } from 'react';
+
+import {
+  getPayments,
+  createPayment,
+  updatePayment,
+  markPaymentAsPaid,
+  deletePayment,
+} from '../../../services/paymentsService';
+import type { Payment } from '../../../services/paymentsService';
+import { initialPaymentForm, type PaymentFormState } from '../types';
+
+interface ToastItem {
+  id: number;
+  type: 'success' | 'error';
+  message: string;
+}
+
+const getApiDetail = (error: unknown): string | null => {
+  if (typeof error !== 'object' || error === null) return null;
+  if (!('response' in error)) return null;
+  const response = (error as { response?: { data?: { detail?: unknown } } })
+    .response;
+  if (!response?.data) return null;
+  return typeof response.data.detail === 'string' ? response.data.detail : null;
+};
+
+export function usePaymentsData() {
+  const [payments, setPayments] = useState<Payment[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const [paymentForm, setPaymentForm] =
+    useState<PaymentFormState>(initialPaymentForm);
+  const [editingPayment, setEditingPayment] = useState<Payment | null>(null);
+  const [editForm, setEditForm] =
+    useState<PaymentFormState>(initialPaymentForm);
+
+  const [deletingId, setDeletingId] = useState<number | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+
+  const showToast = (type: 'success' | 'error', message: string) => {
+    const id = Date.now() + Math.floor(Math.random() * 1000);
+    setToasts((prev) => [...prev, { id, type, message }]);
+    window.setTimeout(() => {
+      setToasts((prev) => prev.filter((item) => item.id !== id));
+    }, 3200);
+  };
+
+  const dismissToast = (id: number) => {
+    setToasts((prev) => prev.filter((item) => item.id !== id));
+  };
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadData = async () => {
+      try {
+        const fetched = await getPayments();
+        if (!cancelled) setPayments(fetched);
+      } catch {
+        if (!cancelled) {
+          setError('No fue posible cargar los pagos.');
+          showToast('error', 'No fue posible cargar los pagos.');
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    void loadData();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const canSavePayment =
+    paymentForm.concept.trim() &&
+    paymentForm.description.trim() &&
+    paymentForm.amount &&
+    Number(paymentForm.amount) > 0 &&
+    paymentForm.due_date;
+
+  const handleCreatePayment = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!canSavePayment) {
+      setError('Completa todos los campos obligatorios.');
+      return;
+    }
+
+    setError(null);
+    setSaving(true);
+
+    try {
+      const created = await createPayment({
+        concept: paymentForm.concept.trim(),
+        description: paymentForm.description.trim(),
+        amount: Number(paymentForm.amount),
+        due_date: paymentForm.due_date,
+      });
+
+      const refreshed = await getPayments();
+      setPayments(refreshed);
+      setPaymentForm(initialPaymentForm);
+      showToast('success', `Pago "${created.concept}" creado correctamente.`);
+    } catch (err: unknown) {
+      const detail = getApiDetail(err);
+      setError(detail || 'No se pudo crear el pago.');
+      showToast('error', detail || 'No se pudo crear el pago.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const startEditing = (payment: Payment) => {
+    setEditingPayment(payment);
+    setEditForm({
+      concept: payment.concept,
+      description: payment.description,
+      amount: String(payment.amount),
+      due_date: payment.due_date,
+    });
+  };
+
+  const cancelEditing = () => {
+    setEditingPayment(null);
+    setEditForm(initialPaymentForm);
+  };
+
+  const handleUpdatePayment = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!editingPayment) return;
+
+    setSaving(true);
+
+    try {
+      await updatePayment(editingPayment.id, {
+        concept: editForm.concept.trim(),
+        description: editForm.description.trim(),
+        amount: Number(editForm.amount),
+        due_date: editForm.due_date,
+      });
+
+      const refreshed = await getPayments();
+      setPayments(refreshed);
+      cancelEditing();
+      showToast('success', 'Pago actualizado correctamente.');
+    } catch (err: unknown) {
+      const detail = getApiDetail(err);
+      showToast('error', detail || 'No se pudo actualizar el pago.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleMarkPaid = async (id: number) => {
+    try {
+      await markPaymentAsPaid(id);
+      const refreshed = await getPayments();
+      setPayments(refreshed);
+      showToast('success', 'Pago marcado como pagado.');
+    } catch (err: unknown) {
+      const detail = getApiDetail(err);
+      showToast('error', detail || 'No se pudo marcar como pagado.');
+    }
+  };
+
+  const requestDelete = (id: number) => setDeletingId(id);
+  const cancelDelete = () => setDeletingId(null);
+
+  const confirmDelete = async () => {
+    if (deletingId === null) return;
+
+    try {
+      await deletePayment(deletingId);
+      const refreshed = await getPayments();
+      setPayments(refreshed);
+      setDeletingId(null);
+      showToast('success', 'Pago eliminado correctamente.');
+    } catch (err: unknown) {
+      const detail = getApiDetail(err);
+      showToast('error', detail || 'No se pudo eliminar el pago.');
+      setDeletingId(null);
+    }
+  };
+
+  return {
+    payments,
+    loading,
+    paymentForm,
+    setPaymentForm,
+    editingPayment,
+    editForm,
+    setEditForm,
+    deletingId,
+    saving,
+    error,
+    canSavePayment,
+    toasts,
+    dismissToast,
+    handleCreatePayment,
+    startEditing,
+    cancelEditing,
+    handleUpdatePayment,
+    handleMarkPaid,
+    requestDelete,
+    cancelDelete,
+    confirmDelete,
+  };
+}

--- a/frontend/src/features/payments/types.ts
+++ b/frontend/src/features/payments/types.ts
@@ -1,0 +1,32 @@
+export type TrafficLight = 'red' | 'yellow' | 'gray';
+
+export interface PaymentFormState {
+  concept: string;
+  description: string;
+  amount: string;
+  due_date: string;
+}
+
+export const initialPaymentForm: PaymentFormState = {
+  concept: '',
+  description: '',
+  amount: '',
+  due_date: '',
+};
+
+export const currency = new Intl.NumberFormat('es-CO', {
+  style: 'currency',
+  currency: 'COP',
+  maximumFractionDigits: 0,
+});
+
+export function getTrafficLight(
+  status: string,
+  dueDate: string
+): TrafficLight {
+  if (status === 'pagado') return 'gray';
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const due = new Date(dueDate + 'T00:00:00');
+  return due < today ? 'red' : 'yellow';
+}

--- a/frontend/src/features/payments/types.ts
+++ b/frontend/src/features/payments/types.ts
@@ -20,10 +20,7 @@ export const currency = new Intl.NumberFormat('es-CO', {
   maximumFractionDigits: 0,
 });
 
-export function getTrafficLight(
-  status: string,
-  dueDate: string
-): TrafficLight {
+export function getTrafficLight(status: string, dueDate: string): TrafficLight {
   if (status === 'pagado') return 'gray';
   const today = new Date();
   today.setHours(0, 0, 0, 0);

--- a/frontend/src/pages/PaymentsPage.tsx
+++ b/frontend/src/pages/PaymentsPage.tsx
@@ -1,0 +1,90 @@
+import PaymentsSkeleton from '../features/payments/components/PaymentsSkeleton';
+import PaymentsToasts from '../features/payments/components/PaymentsToasts';
+import NewPaymentCard from '../features/payments/components/NewPaymentCard';
+import PaymentsTable from '../features/payments/components/PaymentsTable';
+import EditPaymentModal from '../features/payments/components/EditPaymentModal';
+import DeleteConfirmDialog from '../features/payments/components/DeleteConfirmDialog';
+import { usePaymentsData } from '../features/payments/hooks/usePaymentsData';
+
+export default function PaymentsPage() {
+  const {
+    payments,
+    loading,
+    paymentForm,
+    setPaymentForm,
+    editingPayment,
+    editForm,
+    setEditForm,
+    deletingId,
+    saving,
+    error,
+    canSavePayment,
+    toasts,
+    dismissToast,
+    handleCreatePayment,
+    startEditing,
+    cancelEditing,
+    handleUpdatePayment,
+    handleMarkPaid,
+    requestDelete,
+    cancelDelete,
+    confirmDelete,
+  } = usePaymentsData();
+
+  return (
+    <div className="min-h-screen bg-neutral-bg px-6 py-8">
+      <div className="max-w-7xl mx-auto space-y-6">
+        <PaymentsToasts toasts={toasts} onDismiss={dismissToast} />
+
+        <header className="flex flex-col gap-2">
+          <h1 className="text-3xl font-bold text-neutral-text font-hubot tracking-tight">
+            Gestion de Pagos
+          </h1>
+          <p className="text-sm text-neutral-muted">
+            Registra y supervisa las obligaciones financieras pendientes de la
+            empresa.
+          </p>
+        </header>
+
+        {loading ? (
+          <PaymentsSkeleton />
+        ) : (
+          <section className="grid grid-cols-1 xl:grid-cols-3 gap-6">
+            <NewPaymentCard
+              paymentForm={paymentForm}
+              onChange={setPaymentForm}
+              error={error}
+              saving={saving}
+              canSave={!!canSavePayment}
+              onSubmit={handleCreatePayment}
+            />
+
+            <PaymentsTable
+              payments={payments}
+              onMarkPaid={handleMarkPaid}
+              onEdit={startEditing}
+              onDelete={requestDelete}
+            />
+          </section>
+        )}
+
+        {editingPayment && (
+          <EditPaymentModal
+            editForm={editForm}
+            onChange={setEditForm}
+            saving={saving}
+            onSubmit={handleUpdatePayment}
+            onCancel={cancelEditing}
+          />
+        )}
+
+        {deletingId !== null && (
+          <DeleteConfirmDialog
+            onConfirm={confirmDelete}
+            onCancel={cancelDelete}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/services/paymentsService.ts
+++ b/frontend/src/services/paymentsService.ts
@@ -1,0 +1,58 @@
+import api from './api';
+
+export type PaymentStatus = 'pendiente' | 'pagado';
+
+export interface Payment {
+  id: number;
+  concept: string;
+  description: string;
+  amount: string;
+  due_date: string;
+  status: PaymentStatus;
+  paid_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreatePaymentPayload {
+  concept: string;
+  description: string;
+  amount: number;
+  due_date: string;
+}
+
+export interface UpdatePaymentPayload {
+  concept?: string;
+  description?: string;
+  amount?: number;
+  due_date?: string;
+}
+
+export const getPayments = async (): Promise<Payment[]> => {
+  const response = await api.get('/payments/');
+  return response.data;
+};
+
+export const createPayment = async (
+  payload: CreatePaymentPayload
+): Promise<Payment> => {
+  const response = await api.post('/payments/', payload);
+  return response.data;
+};
+
+export const updatePayment = async (
+  id: number,
+  payload: UpdatePaymentPayload
+): Promise<Payment> => {
+  const response = await api.put(`/payments/${id}`, payload);
+  return response.data;
+};
+
+export const markPaymentAsPaid = async (id: number): Promise<Payment> => {
+  const response = await api.patch(`/payments/${id}/mark-paid`);
+  return response.data;
+};
+
+export const deletePayment = async (id: number): Promise<void> => {
+  await api.delete(`/payments/${id}`);
+};


### PR DESCRIPTION
## Objetivo
  Implementar la HU-021: permitir al equipo de Cole&Co registrar pagos pendientes, hacerles seguimiento por estado y visualizar de forma rápida cuáles están próximos a vencer o vencidos mediante
  semaforización.

  ## Cambios Principales
  - **Backend** — Nuevo módulo `cole_co/payments` con modelo, schemas, router y service. Migración Alembic `c3d5e7f9a1b2_add_payments_table` para crear la tabla `payments`.
  - **Frontend** — Nueva página `PaymentsPage` con:
    - Tabla de pagos (`PaymentsTable`) con semaforización visual por estado/vencimiento.
    - Creación rápida (`NewPaymentCard`), edición (`EditPaymentModal`) y eliminación con confirmación (`DeleteConfirmDialog`).
    - Skeleton de carga (`PaymentsSkeleton`) y toasts de feedback (`PaymentsToasts`).
    - Hook `usePaymentsData` que centraliza la lógica de fetch/mutations.
  - **Integración** — Entrada nueva en el sidebar y ruta agregada en `App.tsx`. Servicio `paymentsService` para consumo del API.

  ## Como probarlo
  1. Correr migraciones: `alembic upgrade head` (debe aplicar `c3d5e7f9a1b2`).
  2. Levantar backend y frontend.
  3. Ingresar al módulo Cole&Co → Pagos desde el sidebar.
  4. Crear un pago nuevo desde `NewPaymentCard` y verificar que aparece en la tabla.
  5. Editar el pago, cambiar estado/fecha y validar que la semaforización se actualiza.
  6. Eliminar el pago y confirmar que el diálogo bloquea la acción hasta confirmar.
  7. Verificar que no hay regresiones en deadlines ni en el resto del módulo Family Office.

  ## Notas Adicionales
  - El módulo se ubicó en `cole_co/payments` (no en `family_office/payments`), por lo que la futura HU-023 (comprobante obligatorio al cerrar) tendrá que decidir si aplica también a este módulo o solo a
  deadlines de Family Office.
  - Sin cambios en autenticación/roles más allá del consumo desde la UI.