### PR TITLE
fix: poblar metricas de Family Office con ultimo reporte IA guardado

### DIFF
--- a/frontend/src/pages/FamilyOfficePage.tsx
+++ b/frontend/src/pages/FamilyOfficePage.tsx
@@ -19,6 +19,8 @@ import {
   regenerateDianCalendar,
   OBLIGATION_LABELS,
 } from '../services/deadlineService';
+import { getSavedReportsByCompany } from '../services/reportService';
+import type { SavedReport } from '../services/reportService';
 import { toast } from 'sonner';
 import type { Deadline, ObligationType } from '../services/deadlineService';
 import UploadBalanceModal from '../components/UploadBalanceModal';
@@ -66,7 +68,18 @@ const metrics = [
     icon: Users,
     color: 'bg-primary/10 text-primary',
   },
-];
+] as const;
+
+const currencyFormatter = new Intl.NumberFormat('es-CO', {
+  style: 'currency',
+  currency: 'COP',
+  maximumFractionDigits: 0,
+});
+
+const formatCurrency = (value: number | null | undefined) =>
+  value === null || value === undefined
+    ? '—'
+    : currencyFormatter.format(value);
 
 type Tab = 'balances' | 'vencimientos' | 'cartera';
 
@@ -94,6 +107,7 @@ export default function FamilyOfficePage() {
   // Reportes IA
   const [showReportModal, setShowReportModal] = useState(false);
   const [reportBalanceId, setReportBalanceId] = useState<number | null>(null);
+  const [latestReport, setLatestReport] = useState<SavedReport | null>(null);
 
   // Vencimientos
   const [deadlines, setDeadlines] = useState<Deadline[]>([]);
@@ -207,6 +221,40 @@ export default function FamilyOfficePage() {
       cancelled = true;
     };
   }, [activeCompany]);
+
+  // Cargar último reporte IA para alimentar las métricas
+  useEffect(() => {
+    if (!activeCompany) {
+      setLatestReport(null);
+      return;
+    }
+    let cancelled = false;
+    getSavedReportsByCompany(activeCompany.id)
+      .then((reports) => {
+        if (cancelled) return;
+        const latest = reports.length
+          ? [...reports].sort(
+              (a, b) =>
+                new Date(b.created_at).getTime() -
+                new Date(a.created_at).getTime()
+            )[0]
+          : null;
+        setLatestReport(latest);
+      })
+      .catch(() => {
+        if (!cancelled) setLatestReport(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [activeCompany]);
+
+  const metricsValues = [
+    formatCurrency(latestReport?.total_income),
+    formatCurrency(latestReport?.total_expenses),
+    formatCurrency(latestReport?.net_result),
+    '—',
+  ];
 
   // Cargar vencimientos
   useEffect(() => {
@@ -417,7 +465,7 @@ export default function FamilyOfficePage() {
 
       {/* Métricas */}
       <div className="relative z-10 grid grid-cols-4 gap-4 mb-6">
-        {metrics.map(({ label, value, icon: Icon, color }) => (
+        {metrics.map(({ label, icon: Icon, color }, idx) => (
           <div
             key={label}
             className="bg-neutral-surface border border-neutral-border rounded-2xl p-4 flex items-center gap-4 shadow-sm hover:shadow-md transition-shadow duration-200"
@@ -428,7 +476,9 @@ export default function FamilyOfficePage() {
               <Icon size={20} />
             </div>
             <div>
-              <p className="text-lg font-bold text-neutral-text">{value}</p>
+              <p className="text-lg font-bold text-neutral-text">
+                {metricsValues[idx]}
+              </p>
               <p className="text-xs text-neutral-muted">{label}</p>
             </div>
           </div>

--- a/frontend/src/pages/FamilyOfficePage.tsx
+++ b/frontend/src/pages/FamilyOfficePage.tsx
@@ -77,9 +77,7 @@ const currencyFormatter = new Intl.NumberFormat('es-CO', {
 });
 
 const formatCurrency = (value: number | null | undefined) =>
-  value === null || value === undefined
-    ? '—'
-    : currencyFormatter.format(value);
+  value === null || value === undefined ? '—' : currencyFormatter.format(value);
 
 type Tab = 'balances' | 'vencimientos' | 'cartera';
 


### PR DESCRIPTION
## Objetivo
  Corregir el bug reportado en Family Office: al seleccionar una empresa, las tarjetas de **Ingresos totales**, **Gastos totales**, **Utilidad neta** y **Cartera por cobrar** mostraban siempre `$ 0` porque
  estaban hardcodeadas en el componente.

  ## Cambios Principales
  - `frontend/src/pages/FamilyOfficePage.tsx`:
    - Se elimina el `$ 0` hardcodeado de las 4 métricas.
    - Nuevo `useEffect` que consulta `getSavedReportsByCompany(activeCompany.id)` al cambiar de empresa y guarda el reporte IA más reciente en `latestReport`.
    - Las métricas de **Ingresos**, **Gastos** y **Utilidad neta** ahora se calculan desde `total_income`, `total_expenses` y `net_result` del último reporte guardado.
    - **Cartera por cobrar** muestra `—` por ahora (el dato `accounts_receivable` está en el snapshot pero no se expone aún en `SavedReportResponse`; se hará en un PR siguiente).
    - Formato de moneda en COP con `Intl.NumberFormat('es-CO')`.

  ## Como probarlo
  1. Entrar a Family Office sin empresa seleccionada → las 4 métricas muestran `—`.
  2. Seleccionar una empresa sin reportes IA guardados → las 4 métricas muestran `—`.
  3. Seleccionar una empresa con al menos un reporte IA guardado → Ingresos, Gastos y Utilidad muestran los valores del reporte más reciente en formato COP; Cartera sigue en `—`.
  4. Generar y guardar un nuevo reporte IA, cambiar de empresa y volver → las métricas reflejan el nuevo reporte (el más reciente).
  5. Cambiar rápidamente entre varias empresas → las métricas siempre corresponden a la empresa activa, sin quedarse pegadas.

  ## Notas Adicionales
  - **Pendiente (siguiente PR):** exponer `accounts_receivable` (o el `snapshot` completo) en `SavedReportResponse` del backend para poder poblar **Cartera por cobrar** con datos reales.
  - No requiere migración de base de datos: los reportes guardados ya tienen los campos necesarios.
  - Cambio solo en frontend, sin impacto en endpoints existentes.